### PR TITLE
Remove invalid Claude Code plugin install command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,6 @@ Constraints from CONTRIBUTING.md:
 - **Consistent terminology** — one term per concept throughout a skill
 - **Symptom-based triggering** — the `description` frontmatter should describe observable agent behaviors that signal the skill is needed
 
-## Installation / Distribution
-
-```bash
-npx skills add homeassistant-ai/skills
-```
-
-Works with 26+ AI coding agents supporting the Agent Skills standard.
-
 ## Validation
 
 CI runs `skills-ref validate` on every PR and push to `main` that touches `skills/**`. To validate locally:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,17 @@ Constraints from CONTRIBUTING.md:
 
 ## Installation / Distribution
 
-Skills are distributed two ways from the same repo:
-- **Cross-agent (npx):** `npx skills add homeassistant-ai/skills`
-- **Claude Code plugin:** `claude plugin add homeassistant-ai/skills`
+```bash
+npx skills add homeassistant-ai/skills
+```
 
-## No Build System
+Works with 26+ AI coding agents supporting the Agent Skills standard.
 
-This is a pure content repository — no build, lint, test, or CI commands exist. Validation is manual: ensure SKILL.md files meet the format and constraints above.
+## Validation
+
+CI runs `skills-ref validate` on every PR and push to `main` that touches `skills/**`. To validate locally:
+
+```bash
+pip install skills-ref
+python -m skills_ref.cli validate skills/<skill-name>
+```

--- a/README.md
+++ b/README.md
@@ -10,19 +10,11 @@ Community-contributed [Agent Skills](https://agentskills.io) for Home Assistant 
 
 ## Installation
 
-### Cross-agent (Claude Code, Cursor, Copilot, VS Code, Gemini CLI, and others)
-
 ```bash
 npx skills add homeassistant-ai/skills
 ```
 
-This command works with 26+ AI coding agents supporting the Agent Skills standard.
-
-### Claude Code plugin
-
-```bash
-claude plugin add homeassistant-ai/skills
-```
+Works with 26+ AI coding agents supporting the Agent Skills standard: Claude Code, Cursor, Copilot, VS Code, Gemini CLI, and others.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Remove the `claude plugin add homeassistant-ai/skills` instruction from the README. That command does not exist.
- Claude Code plugins require a separate marketplace repo, which is tracked in [discussion #512](https://github.com/homeassistant-ai/ha-mcp/discussions/512).
- The cross-agent `npx skills add` install path works and remains in the README.

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)