### PR TITLE
Add Anthropic agent skills marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/anthropic-agent-skills"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` registering `anthropics/anthropic-agent-skills` as an extra known marketplace
- Makes the skill-creator skill from Anthropic available to contributors, providing guidance for creating effective agent skills

## Test plan
- [ ] Verify `.claude/settings.json` is valid JSON
- [ ] Confirm the marketplace is accessible in Claude Code after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)