### PR TITLE
Expand home-assistant-best-practices with reference files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Constraints from CONTRIBUTING.md:
 - Max **500 lines** per SKILL.md
 - Reference files must be **one level deep** only (e.g. `references/example.yaml`)
 - Use **forward slashes** in all file paths
-- Optional subdirectories: `references/` (additional docs), `scripts/` (utility scripts)
+- Optional subdirectories: `references/` (additional docs), `scripts/` (utility scripts), `assets/` (static resources)
 
 ## Skill Authoring Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,13 @@ skills/
     SKILL.md              # Required
     references/           # Optional: additional docs loaded on demand
     scripts/              # Optional: utility scripts
+    assets/               # Optional: static resources (templates, data files)
 ```
 
 ### SKILL.md requirements
 
 - **YAML frontmatter** with `name` (letters, numbers, hyphens only; 64 chars max) and `description` (1024 chars max).
-- **`description`** in third person, starting with "Use when..." to describe triggering conditions and symptoms. Don't summarize the skill's workflow.
+- **`description`** in third person. Describe what the skill does and when to use it. Include keywords that help agents match tasks. Don't summarize the skill's workflow.
 - **Body** under 500 lines. Split into reference files if approaching this limit.
 - **Reference files** one level deep from SKILL.md—no nested references.
 - **Forward slashes** in all file paths.

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -1,0 +1,601 @@
+# Automation Patterns
+
+This document covers native Home Assistant automation constructs that should be used instead of templates.
+
+## Table of Contents
+1. [Native Conditions](#native-conditions)
+2. [Trigger Types](#trigger-types)
+3. [Wait Actions](#wait-actions)
+4. [Automation Modes](#automation-modes)
+5. [if/then vs choose](#ifthen-vs-choose)
+6. [Trigger IDs](#trigger-ids)
+
+---
+
+## Native Conditions
+
+### State Condition
+
+The most common condition type. Supports multiple states, attributes, and duration.
+
+```yaml
+# Single state
+condition: state
+entity_id: light.living_room
+state: "on"
+
+# Multiple acceptable states (OR logic)
+condition: state
+entity_id: vacuum.robot
+state:
+  - "cleaning"
+  - "returning"
+
+# Attribute check
+condition: state
+entity_id: climate.thermostat
+attribute: hvac_action
+state: "heating"
+
+# Duration check (entity has been in state for X time)
+condition: state
+entity_id: binary_sensor.motion
+state: "off"
+for:
+  minutes: 5
+```
+
+### Numeric State Condition
+
+For numeric comparisons. Always prefer over template conditions with `| float`.
+
+```yaml
+# Above threshold
+condition: numeric_state
+entity_id: sensor.temperature
+above: 25
+
+# Below threshold
+condition: numeric_state
+entity_id: sensor.humidity
+below: 30
+
+# Range
+condition: numeric_state
+entity_id: sensor.battery
+above: 20
+below: 80
+
+# Attribute numeric check
+condition: numeric_state
+entity_id: sun.sun
+attribute: elevation
+below: -6
+```
+
+### Time Condition
+
+For time-based restrictions. Handles midnight crossing automatically.
+
+```yaml
+# Time range (handles midnight crossing!)
+condition: time
+after: "22:00:00"
+before: "06:00:00"
+
+# Weekday filter
+condition: time
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+
+# Combined
+condition: time
+after: "09:00:00"
+before: "17:00:00"
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+```
+
+### Sun Condition
+
+For sunrise/sunset-based logic with optional offsets.
+
+```yaml
+# After sunset
+condition: sun
+after: sunset
+
+# Before sunrise with offset
+condition: sun
+before: sunrise
+before_offset: "01:00:00"
+
+# After sunset by 30 minutes
+condition: sun
+after: sunset
+after_offset: "00:30:00"
+```
+
+### Zone Condition
+
+For presence detection based on zones.
+
+```yaml
+condition: zone
+entity_id: person.john
+zone: zone.home
+
+# Or check if NOT in zone
+condition: not
+conditions:
+  - condition: zone
+    entity_id: person.john
+    zone: zone.home
+```
+
+### And/Or/Not Conditions
+
+Combine conditions with logical operators.
+
+```yaml
+# AND (default when multiple conditions listed)
+condition: and
+conditions:
+  - condition: state
+    entity_id: light.kitchen
+    state: "on"
+  - condition: numeric_state
+    entity_id: sensor.brightness
+    below: 100
+
+# OR
+condition: or
+conditions:
+  - condition: state
+    entity_id: person.john
+    state: "home"
+  - condition: state
+    entity_id: person.jane
+    state: "home"
+
+# NOT
+condition: not
+conditions:
+  - condition: state
+    entity_id: alarm_control_panel.home
+    state: "armed_away"
+
+# Shorthand syntax
+conditions:
+  - and:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "on"
+      - condition: time
+        after: "08:00:00"
+```
+
+### Template Condition Shorthand
+
+When you must use a template, use the shorthand syntax:
+
+```yaml
+# Shorthand (preferred when template is necessary)
+conditions:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+  
+# Long form (equivalent)
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+---
+
+## Trigger Types
+
+### State Trigger
+
+The workhorse trigger. Fires on entity state changes.
+
+```yaml
+# Basic state change to specific value
+trigger:
+  - trigger: state
+    entity_id: binary_sensor.motion
+    to: "on"
+
+# From specific state
+trigger:
+  - trigger: state
+    entity_id: light.bedroom
+    from: "off"
+    to: "on"
+
+# Any state change (omit to/from)
+trigger:
+  - trigger: state
+    entity_id: sensor.temperature
+
+# Attribute change
+trigger:
+  - trigger: state
+    entity_id: climate.thermostat
+    attribute: current_temperature
+
+# Duration trigger (entity has been in state for X)
+trigger:
+  - trigger: state
+    entity_id: light.porch
+    to: "on"
+    for:
+      minutes: 30
+
+# Multiple entities
+trigger:
+  - trigger: state
+    entity_id:
+      - binary_sensor.motion_kitchen
+      - binary_sensor.motion_hallway
+    to: "on"
+```
+
+### Numeric State Trigger
+
+Fires when crossing a threshold.
+
+```yaml
+trigger:
+  - trigger: numeric_state
+    entity_id: sensor.temperature
+    above: 25
+    for:
+      minutes: 5
+```
+
+### Time Trigger
+
+Fires at specific times.
+
+```yaml
+# Fixed time
+trigger:
+  - trigger: time
+    at: "07:00:00"
+
+# Input datetime helper
+trigger:
+  - trigger: time
+    at: input_datetime.morning_alarm
+
+# Time pattern (every 5 minutes)
+trigger:
+  - trigger: time_pattern
+    minutes: "/5"
+
+# Every hour at :30
+trigger:
+  - trigger: time_pattern
+    minutes: 30
+```
+
+### Sun Trigger
+
+Fires at sunrise/sunset with optional offset.
+
+```yaml
+trigger:
+  - trigger: sun
+    event: sunset
+    offset: "-00:30:00"  # 30 minutes before sunset
+```
+
+### Event Trigger
+
+Fires on Home Assistant events.
+
+```yaml
+# ZHA button event
+trigger:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:11:22:33:44:55:66:77"
+      command: "on"
+
+# Custom event
+trigger:
+  - trigger: event
+    event_type: my_custom_event
+```
+
+### MQTT Trigger
+
+Fires on MQTT messages.
+
+```yaml
+trigger:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/button/action"
+    payload: "single"
+```
+
+### Device Trigger (Use Sparingly)
+
+Device triggers use device_id which is NOT persistent. Prefer state triggers.
+
+```yaml
+# Avoid when possible - device_id changes on re-add
+trigger:
+  - trigger: device
+    domain: mqtt
+    device_id: abc123
+    type: action
+    subtype: single
+```
+
+---
+
+## Wait Actions
+
+### wait_for_trigger (Preferred)
+
+Event-driven wait. More efficient than polling.
+
+```yaml
+# Wait for door to close
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+  continue_on_timeout: false  # Stop automation if timeout
+
+# Wait for any of multiple triggers
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+    - trigger: event
+      event_type: mobile_app_notification_action
+      event_data:
+        action: "CLOSE_DOOR"
+```
+
+### wait_template (Use Sparingly)
+
+Polls until template is true. **Immediately continues if already true.**
+
+```yaml
+# Only use when wait_for_trigger cannot express the condition
+- wait_template: "{{ states('sensor.temperature') | float > 25 }}"
+  timeout:
+    minutes: 10
+```
+
+**Key difference:**
+- `wait_for_trigger` waits for a **change** to occur
+- `wait_template` waits for a **condition** to be true (passes immediately if already true)
+
+### Checking Wait Results
+
+Both waits set `wait.completed` and `wait.remaining`:
+
+```yaml
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+
+- if:
+    - "{{ not wait.completed }}"
+  then:
+    - action: notify.mobile_app
+      data:
+        message: "Door still open after 5 minutes!"
+```
+
+---
+
+## Automation Modes
+
+The `mode` determines what happens when an automation triggers while already running.
+
+### single (Default)
+
+New triggers are ignored while running. A warning is logged.
+
+**Best for:** One-shot notifications, actions that shouldn't overlap.
+
+```yaml
+automation:
+  - alias: "Doorbell notification"
+    mode: single
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+    action:
+      - action: notify.mobile_app
+        data:
+          message: "Someone at the door!"
+```
+
+### restart
+
+Stops the current run and starts fresh. Timer-based actions are reset.
+
+**Best for:** Motion-activated lights with timeout, retriggerable delays.
+
+```yaml
+mode: restart  # Re-trigger resets the timer
+```
+
+See `references/examples.yaml` Example 1 for a complete motion-light automation using restart + wait_for_trigger.
+
+### queued
+
+Queues new triggers to run after current run completes.
+
+**Best for:** Sequential actions, door locks, garage doors.
+
+```yaml
+automation:
+  - alias: "Garage door controller"
+    mode: queued
+    max: 5  # Maximum queue size
+    trigger:
+      - trigger: state
+        entity_id: input_boolean.garage_door_trigger
+        to: "on"
+    action:
+      - action: cover.toggle
+        target:
+          entity_id: cover.garage_door
+      - delay:
+          seconds: 20  # Wait for door to fully open/close
+```
+
+### parallel
+
+Runs multiple instances simultaneously.
+
+**Best for:** Per-entity actions with `trigger.entity_id`, notifications that shouldn't block.
+
+```yaml
+automation:
+  - alias: "Window open too long"
+    mode: parallel
+    max: 10  # Maximum parallel runs
+    trigger:
+      - trigger: state
+        entity_id:
+          - binary_sensor.window_bedroom
+          - binary_sensor.window_kitchen
+          - binary_sensor.window_living
+        to: "on"
+        for:
+          minutes: 30
+    action:
+      - action: notify.mobile_app
+        data:
+          message: "{{ trigger.to_state.name }} has been open for 30 minutes"
+```
+
+### max_exceeded
+
+Control logging when max runs are exceeded:
+
+```yaml
+automation:
+  - alias: "Quiet automation"
+    mode: single
+    max_exceeded: silent  # No warning logged
+```
+
+---
+
+## if/then vs choose
+
+### if/then/else
+
+Use for simple binary conditions:
+
+```yaml
+actions:
+  - if:
+      - condition: state
+        entity_id: sun.sun
+        state: "below_horizon"
+    then:
+      - action: light.turn_on
+        target:
+          entity_id: light.porch
+    else:
+      - action: light.turn_off
+        target:
+          entity_id: light.porch
+```
+
+### choose
+
+Use for multiple branches (like switch/case):
+
+```yaml
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: "morning"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.morning
+
+      - conditions:
+          - condition: trigger
+            id: "evening"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.evening
+
+    default:
+      - action: light.turn_off
+        target:
+          area_id: living_room
+```
+
+---
+
+## Trigger IDs
+
+Assign IDs to triggers for use in conditions and choose:
+
+```yaml
+automation:
+  - alias: "Multi-trigger automation"
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "on"
+        id: "motion_on"
+
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "off"
+        for:
+          minutes: 5
+        id: "motion_off"
+
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: "motion_on"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.hallway
+
+          - conditions:
+              - condition: trigger
+                id: "motion_off"
+            sequence:
+              - action: light.turn_off
+                target:
+                  entity_id: light.hallway
+```
+
+Access trigger info in templates with `trigger.id`, `trigger.entity_id`, `trigger.to_state`, etc.

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -1,0 +1,417 @@
+# Device Control Patterns
+
+Best practices for controlling devices, triggering from Zigbee buttons/remotes, and structuring service calls.
+
+---
+
+## Entity ID vs Device ID
+
+### The Core Problem
+
+`device_id` is a Home Assistant internal identifier that **changes when a device is re-added** (e.g., after Zigbee mesh repair, integration re-setup, or hardware replacement). Automations using `device_id` will break silently.
+
+`entity_id` is user-controllable, stable across device re-adds, and can be renamed for clarity.
+
+### Device Triggers vs State Triggers
+
+```yaml
+# ❌ WRONG - device_id changes if device is re-added
+trigger:
+  - platform: device
+    device_id: abc123def456
+    domain: binary_sensor
+    type: motion
+
+# ✅ RIGHT - entity_id is stable and renameable
+trigger:
+  - trigger: state
+    entity_id: binary_sensor.hallway_motion
+    to: "on"
+```
+
+### When Device ID is Acceptable
+
+The only cases where `device_id` might be acceptable:
+
+1. **Device-only triggers** - Some devices expose triggers without entities (see Zigbee section)
+2. **Temporary automations** - Quick tests you'll delete
+3. **UI-created automations** - The UI defaults to device triggers; convert to entity triggers for production
+
+---
+
+## Service Calls Best Practices
+
+### Use target: Structure
+
+Modern Home Assistant service calls use the `target:` key to specify entities, areas, or devices:
+
+```yaml
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+### Target Types
+
+| Type | Use case | Persistence |
+|------|----------|-------------|
+| `entity_id` | Specific entities | ✅ Stable (recommended) |
+| `area_id` | All entities in a room | ✅ Stable |
+| `device_id` | All entities on a device | ❌ Changes on re-add |
+
+### Multiple Targets
+
+```yaml
+# Multiple entities
+target:
+  entity_id:
+    - light.living_room
+    - light.kitchen
+    - light.bedroom
+
+# Area targeting (all lights in living room)
+target:
+  area_id: living_room
+
+# Combined (entities + areas)
+target:
+  entity_id: light.hallway
+  area_id:
+    - bedroom
+    - bathroom
+```
+
+### Template in Targets
+
+```yaml
+# Dynamic entity selection
+target:
+  entity_id: "{{ state_attr('sensor.motion_zone', 'light_entity') }}"
+
+# All lights currently on (advanced)
+target:
+  entity_id: >
+    {{ states.light 
+       | selectattr('state', 'eq', 'on') 
+       | map(attribute='entity_id') 
+       | list }}
+```
+
+---
+
+## Zigbee Button/Remote Patterns
+
+### ZHA (Zigbee Home Automation)
+
+ZHA buttons fire `zha_event` events. Use **event triggers** with `device_ieee` (the device's IEEE address), which is **persistent** across re-adds.
+
+```yaml
+# ✅ ZHA button trigger - device_ieee is persistent
+trigger:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"
+      command: "toggle"
+```
+
+For a complete multi-button remote with trigger_id + choose, see `references/examples.yaml` Example 2.
+
+#### Finding ZHA Event Data
+
+1. Go to **Developer Tools → Events**
+2. Subscribe to `zha_event`
+3. Press your button
+4. Copy the `device_ieee` and `command` values
+
+### Zigbee2MQTT (Z2M)
+
+Z2M creates **MQTT device triggers** that are autodiscovered. These are acceptable because Z2M manages the device-to-trigger mapping.
+
+```yaml
+# ✅ Z2M device trigger - autodiscovered
+trigger:
+  - trigger: device
+    device_id: abc123def456  # OK for Z2M, managed by autodiscovery
+    domain: mqtt
+    type: action
+    subtype: single
+
+# Alternative: MQTT topic trigger (more explicit)
+trigger:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/Bedroom Button/action"
+    payload: "single"
+```
+
+#### Z2M Device Trigger Discovery
+
+1. Open your device in **Settings → Devices**
+2. Look for available triggers under "Automations"
+3. The UI will show valid trigger types and subtypes
+
+### Z2M vs ZHA Comparison
+
+| Aspect | ZHA | Zigbee2MQTT |
+|--------|-----|-------------|
+| Trigger type | `event` trigger | `device` trigger or `mqtt` trigger |
+| Identifier | `device_ieee` (persistent) | `device_id` (autodiscovered) |
+| Event name | `zha_event` | MQTT device trigger |
+| Button actions | `command` field | `type` and `subtype` |
+
+---
+
+## Domain-Specific Patterns
+
+### Lights
+
+```yaml
+# Turn on with brightness and transition
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 80
+      transition: 2
+      color_temp_kelvin: 3000
+
+# Turn on multiple lights differently
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.main
+    data:
+      brightness_pct: 100
+  - action: light.turn_on
+    target:
+      entity_id: light.accent
+    data:
+      brightness_pct: 30
+      rgb_color: [255, 147, 41]
+```
+
+### Climate
+
+```yaml
+# Set temperature with HVAC mode
+action:
+  - action: climate.set_temperature
+    target:
+      entity_id: climate.living_room
+    data:
+      temperature: 22
+      hvac_mode: heat
+
+# Set preset mode
+action:
+  - action: climate.set_preset_mode
+    target:
+      entity_id: climate.living_room
+    data:
+      preset_mode: away
+```
+
+### Covers (Blinds/Shades)
+
+```yaml
+# Set to specific position (0 = closed, 100 = open)
+action:
+  - action: cover.set_cover_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      position: 50
+
+# Tilt control
+action:
+  - action: cover.set_cover_tilt_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      tilt_position: 75
+```
+
+### Media Players
+
+```yaml
+# Play media
+action:
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      media_content_id: "https://example.com/audio.mp3"
+      media_content_type: music
+
+# Set volume (0.0 to 1.0)
+action:
+  - action: media_player.volume_set
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      volume_level: 0.5
+```
+
+### Notifications
+
+```yaml
+# Mobile app notification
+action:
+  - action: notify.mobile_app_phone
+    data:
+      title: "Motion Detected"
+      message: "Motion in {{ trigger.to_state.attributes.friendly_name }}"
+      data:
+        tag: "motion-alert"
+        actions:
+          - action: "DISMISS"
+            title: "Dismiss"
+          - action: "VIEW_CAMERA"
+            title: "View Camera"
+
+# Persistent notification
+action:
+  - action: notify.persistent_notification
+    data:
+      title: "Reminder"
+      message: "Check the laundry"
+      notification_id: "laundry_reminder"
+```
+
+---
+
+## Vacuum Control
+
+```yaml
+# Start cleaning
+action:
+  - action: vacuum.start
+    target:
+      entity_id: vacuum.roborock
+
+# Return to dock
+action:
+  - action: vacuum.return_to_base
+    target:
+      entity_id: vacuum.roborock
+
+# Clean specific rooms (integration-specific)
+action:
+  - action: vacuum.send_command
+    target:
+      entity_id: vacuum.roborock
+    data:
+      command: app_segment_clean
+      params:
+        - 16  # Room ID
+        - 17
+```
+
+---
+
+## Response Data
+
+Some services return data. Use `response_variable` to capture it:
+
+```yaml
+action:
+  - action: weather.get_forecasts
+    target:
+      entity_id: weather.home
+    data:
+      type: hourly
+    response_variable: forecast
+  - action: notify.mobile_app_phone
+    data:
+      message: "Tomorrow's high: {{ forecast['weather.home'].forecast[0].temperature }}°C"
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Using entity_id in data instead of target
+
+```yaml
+# WRONG (deprecated)
+action:
+  - action: light.turn_on
+    data:
+      entity_id: light.living_room
+      brightness: 255
+
+# RIGHT
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness: 255
+```
+
+### ❌ Hardcoding device_id for regular devices
+
+```yaml
+# WRONG - breaks on device re-add
+action:
+  - action: light.turn_on
+    target:
+      device_id: abc123def456
+
+# RIGHT
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+```
+
+### ❌ Forgetting service data structure
+
+```yaml
+# WRONG - brightness_pct at wrong level
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    brightness_pct: 100
+
+# RIGHT - brightness_pct inside data
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+---
+
+## Quick Reference: Service Call Structure
+
+```yaml
+action:
+  - action: domain.service_name   # Required
+    target:                       # Optional but recommended
+      entity_id: entity.id        # Single or list
+      area_id: area_name          # Single or list
+      device_id: device_id        # Avoid except for Z2M
+    data:                         # Service-specific parameters
+      parameter: value
+    response_variable: result     # Capture response (if needed)
+```
+
+## Quick Reference: Trigger Types for Devices
+
+| Device Type | ZHA | Zigbee2MQTT | Generic |
+|-------------|-----|-------------|---------|
+| Button/Remote | `event` (zha_event) | `device` or `mqtt` | `state` |
+| Motion sensor | `state` | `state` | `state` |
+| Door/Window | `state` | `state` | `state` |
+| Temperature | `state` or `numeric_state` | `state` or `numeric_state` | `state` or `numeric_state` |
+| Switch | `state` | `state` | `state` |
+
+Always prefer `state` triggers with `entity_id` for sensors and switches. Only use event/device triggers for stateless devices (buttons, remotes).

--- a/skills/home-assistant-best-practices/references/examples.yaml
+++ b/skills/home-assistant-best-practices/references/examples.yaml
@@ -1,0 +1,221 @@
+# =============================================================================
+# Home Assistant Best Practices - Compound Examples
+# =============================================================================
+# Each example demonstrates MULTIPLE best practices working together.
+# For individual patterns, see the corresponding reference file.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 1: Motion-Activated Light (restart mode)
+# -----------------------------------------------------------------------------
+# Demonstrates: restart mode, state trigger, native time condition, wait_for_trigger
+# Best practice: Use restart mode so re-triggering resets the timeout
+
+automation:
+  - id: motion_light_hallway
+    alias: "Hallway Motion Light"
+    description: "Turn on hallway light when motion detected, auto-off after 3 minutes"
+    mode: restart  # Re-trigger resets the timer
+
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.hallway_motion
+        to: "on"
+
+    condition:
+      # Native time condition - no template needed
+      - condition: time
+        after: "06:00:00"
+        before: "23:00:00"
+
+    action:
+      - action: light.turn_on
+        target:
+          entity_id: light.hallway
+        data:
+          brightness_pct: 80
+          transition: 1
+
+      # wait_for_trigger - event-driven, waits for the change
+      - wait_for_trigger:
+          - trigger: state
+            entity_id: binary_sensor.hallway_motion
+            to: "off"
+            for:
+              minutes: 3
+        timeout:
+          minutes: 10
+        continue_on_timeout: true
+
+      - action: light.turn_off
+        target:
+          entity_id: light.hallway
+        data:
+          transition: 3
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 2: Multi-Button Remote with trigger_id
+# -----------------------------------------------------------------------------
+# Demonstrates: ZHA event trigger, device_ieee (persistent), trigger_id, choose
+# Best practice: Use device_ieee instead of device_id for ZHA
+
+  - id: bedroom_remote_control
+    alias: "Bedroom Remote Control"
+    description: "Handle single, double, and hold presses on ZHA button"
+    mode: single
+
+    trigger:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"  # Replace with your device
+          command: "single"
+        id: single_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "double"
+        id: double_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "hold"
+        id: hold
+
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: single_press
+            sequence:
+              - action: light.toggle
+                target:
+                  entity_id: light.bedroom
+
+          - conditions:
+              - condition: trigger
+                id: double_press
+            sequence:
+              - action: light.turn_on
+                target:
+                  area_id: bedroom
+                data:
+                  brightness_pct: 100
+
+          - conditions:
+              - condition: trigger
+                id: hold
+            sequence:
+              - action: light.turn_off
+                target:
+                  area_id: bedroom
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 3: Door Lock Notification with Queued Mode
+# -----------------------------------------------------------------------------
+# Demonstrates: queued mode, state condition with attribute, not condition, template message
+# Best practice: Use queued mode when order matters
+
+  - id: door_unlock_notification
+    alias: "Door Unlock Notification"
+    description: "Notify when door is unlocked, show who unlocked it"
+    mode: queued  # Process each unlock event in order
+    max: 10
+
+    trigger:
+      - trigger: state
+        entity_id: lock.front_door
+        to: "unlocked"
+
+    condition:
+      # Native not + state condition with attribute check - no template
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: lock.front_door
+            attribute: changed_by
+            state: "auto_unlock"
+
+    action:
+      - action: notify.mobile_app_phone
+        data:
+          title: "Front Door Unlocked"
+          message: "Unlocked by {{ state_attr('lock.front_door', 'changed_by') }}"
+          data:
+            tag: "door-unlock"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 4: Parallel Mode for Per-Entity Actions
+# -----------------------------------------------------------------------------
+# Demonstrates: parallel mode, multi-entity trigger, trigger variable in template target
+# Best practice: Use parallel mode when actions are independent per-entity
+
+  - id: window_open_climate_off
+    alias: "Turn Off Climate When Window Opens"
+    description: "Turn off climate in room when window is opened"
+    mode: parallel  # Handle multiple windows independently
+    max: 10
+
+    trigger:
+      - trigger: state
+        entity_id:
+          - binary_sensor.bedroom_window
+          - binary_sensor.living_room_window
+          - binary_sensor.kitchen_window
+        to: "on"
+
+    action:
+      # Use trigger variable to determine which room
+      - action: climate.turn_off
+        target:
+          entity_id: >
+            {% set room = trigger.entity_id.split('.')[1].replace('_window', '') %}
+            climate.{{ room }}
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 5: Doorbell with if/then and Native Time Condition
+# -----------------------------------------------------------------------------
+# Demonstrates: if/then action, native time condition, quiet hours logic
+# Best practice: Use if/then for simple binary, choose for multiple branches
+
+  - id: doorbell_announcement
+    alias: "Doorbell Announcement"
+    description: "Announce doorbell with different messages based on time"
+    mode: single
+
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+
+    action:
+      - if:
+          - condition: time
+            after: "22:00:00"
+            before: "08:00:00"
+        then:
+          # Quiet hours - just notification
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"
+        else:
+          # Normal hours - announce and notification
+          - action: tts.speak
+            target:
+              entity_id: tts.google_say
+            data:
+              media_player_entity_id: media_player.living_room_speaker
+              message: "Someone is at the front door"
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -1,0 +1,696 @@
+# Helper Selection Guide
+
+This document covers Home Assistant's built-in helpers and integrations that should be used instead of template sensors or complex automations.
+
+## Table of Contents
+1. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
+2. [Rate and Change](#rate-and-change) - derivative, threshold
+3. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
+4. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
+5. [Counting and Timing](#counting-and-timing) - counter, timer
+6. [Scheduling](#scheduling) - schedule, time of day (tod)
+7. [Entity Grouping](#entity-grouping) - group, binary sensor groups
+
+---
+
+## Numeric Aggregation
+
+### min_max
+
+**Use for:** Combining multiple sensors to get min, max, mean, median, sum, or last value across all of them.
+
+**Instead of:**
+```yaml
+# WRONG - Template sensor for averaging
+template:
+  - sensor:
+      - name: "Average Temperature"
+        state: >
+          {{ ((states('sensor.temp_bedroom') | float) +
+              (states('sensor.temp_living') | float) +
+              (states('sensor.temp_kitchen') | float)) / 3 }}
+```
+
+**Use this:**
+```yaml
+# RIGHT - min_max helper
+sensor:
+  - platform: min_max
+    name: "Average Temperature"
+    type: mean
+    entity_ids:
+      - sensor.temp_bedroom
+      - sensor.temp_living
+      - sensor.temp_kitchen
+```
+
+**Available types:** `min`, `max`, `mean`, `median`, `last`, `sum`
+
+**Key behaviors:**
+- Ignores `unknown` states (except `sum` which goes to unknown)
+- Returns error if unit of measurement differs between sensors
+- For spiky values, filter with statistics sensor first
+
+**Common uses:**
+- Average house temperature from multiple room sensors
+- Maximum power consumption across circuits
+- Sum of all solar panel production sensors
+
+---
+
+### statistics
+
+**Use for:** Statistical analysis over time for a single sensor (mean, median, stdev, change, variance, etc.).
+
+**Instead of:**
+```yaml
+# WRONG - Complex template tracking history
+template:
+  - sensor:
+      - name: "Temperature Change"
+        state: "{{ states('sensor.temp') | float - state_attr('sensor.temp', 'last_value') | float(0) }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Statistics helper
+sensor:
+  - platform: statistics
+    name: "Temperature Change (5 min)"
+    entity_id: sensor.temperature
+    state_characteristic: change
+    max_age:
+      minutes: 5
+    sampling_size: 50
+```
+
+**Available characteristics:**
+- `mean`, `median`, `average_linear`, `average_step`, `average_timeless`
+- `standard_deviation`, `variance`
+- `change`, `change_second`, `change_sample`
+- `count`, `count_binary_on`, `count_binary_off`
+- `total`, `noisiness`
+- `datetime_newest`, `datetime_oldest`, `datetime_value_max`, `datetime_value_min`
+- `value_max`, `value_min`, `quantiles`
+
+**Key behaviors:**
+- Time-based (`max_age`) vs count-based (`sampling_size`) buffering
+- If using `max_age`, ensure frequent enough readings to cover the period
+- Different from Long-Term Statistics (which is automatic for sensors with `state_class`)
+
+**Common uses:**
+- Humidity change over last hour
+- Standard deviation of power readings (detect anomalies)
+- Count of motion sensor activations in last 24 hours
+
+---
+
+## Rate and Change
+
+### derivative
+
+**Use for:** Calculating rate of change over time.
+
+**Instead of:**
+```yaml
+# WRONG - Template calculating delta manually
+template:
+  - sensor:
+      - name: "Power Rate"
+        state: "{{ (states('sensor.power') | float - states('sensor.power_previous') | float) / 60 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Derivative helper
+sensor:
+  - platform: derivative
+    name: "Power Rate of Change"
+    source: sensor.power
+    unit_time: min
+    time_window:
+      minutes: 5
+```
+
+**Parameters:**
+- `unit_time`: s, min, h, d - determines output unit (e.g., W/min)
+- `time_window`: Smoothing window using Simple Moving Average
+- `round`: Decimal places for output
+
+**Key behaviors:**
+- Without `time_window`, calculates between consecutive updates only
+- Can show large negative spikes when source resets to 0 (total_increasing sensors)
+- Use `force_update` option if source updates infrequently
+
+**Common uses:**
+- Energy production rate (kW from kWh sensor)
+- Temperature change rate (detect HVAC efficiency)
+- Water flow rate from cumulative meter
+
+---
+
+### threshold
+
+**Use for:** Creating a binary sensor that turns on/off when a numeric sensor crosses a threshold.
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor
+template:
+  - binary_sensor:
+      - name: "High Temperature"
+        state: "{{ states('sensor.temperature') | float > 25 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Threshold helper
+binary_sensor:
+  - platform: threshold
+    name: "High Temperature"
+    entity_id: sensor.temperature
+    upper: 25
+    hysteresis: 1
+```
+
+**Parameters:**
+- `upper`: Threshold for "on" when value exceeds
+- `lower`: Threshold for "on" when value drops below
+- `hysteresis`: Buffer zone to prevent rapid toggling
+
+**Hysteresis explained:**
+```
+With upper: 25 and hysteresis: 1:
+- Turns ON when value rises ABOVE 26 (25 + 1)
+- Turns OFF when value falls BELOW 24 (25 - 1)
+```
+
+**Common uses:**
+- Low battery warning (lower threshold)
+- High humidity alert
+- Air quality threshold alerts
+- Detect temperature rising/falling (use with derivative)
+
+---
+
+## Time-Based Tracking
+
+### utility_meter
+
+**Use for:** Tracking consumption with periodic resets (energy, water, gas billing cycles).
+
+**Instead of:**
+```yaml
+# WRONG - Automation with counter tracking monthly usage
+automation:
+  - alias: "Reset monthly energy"
+    trigger:
+      - trigger: time
+        at: "00:00:00"
+    condition:
+      - "{{ now().day == 1 }}"
+    action:
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.monthly_energy
+        data:
+          value: 0
+```
+
+**Use this:**
+```yaml
+# RIGHT - Utility meter
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+  monthly_energy:
+    source: sensor.energy_consumption
+    cycle: monthly
+```
+
+**Cycle options:** `quarter-hourly`, `hourly`, `daily`, `weekly`, `monthly`, `bimonthly`, `quarterly`, `yearly`
+
+**Advanced features:**
+- **Tariffs:** Track peak/off-peak separately
+- **Offset:** Start cycle on specific day (e.g., billing date)
+- **Cron:** Custom reset schedules
+- **Delta:** For sensors that report delta values
+
+```yaml
+# Utility meter with tariffs
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+    tariffs:
+      - peak
+      - offpeak
+```
+
+Then use automation to switch tariffs:
+```yaml
+automation:
+  - alias: "Switch to peak tariff"
+    trigger:
+      - trigger: time
+        at: "07:00:00"
+    action:
+      - action: utility_meter.select_tariff
+        target:
+          entity_id: utility_meter.daily_energy
+        data:
+          tariff: peak
+```
+
+**Common uses:**
+- Daily/monthly energy consumption
+- Water usage per billing cycle
+- Gas consumption tracking
+
+---
+
+### history_stats
+
+**Use for:** Statistics about how long/often an entity has been in a specific state.
+
+```yaml
+sensor:
+  - platform: history_stats
+    name: "Lights on today"
+    entity_id: light.living_room
+    state: "on"
+    type: time
+    start: "{{ now().replace(hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+```
+
+**Types:**
+- `time`: Duration in hours
+- `ratio`: Percentage of time
+- `count`: Number of state changes to the monitored state
+
+**Key behaviors:**
+- Limited by recorder's `purge_keep_days`
+- Updates when source changes or once per minute
+
+**Common uses:**
+- How long lights were on today
+- Percentage of time home was occupied
+- Count of door openings per day
+
+---
+
+### integration (Riemann sum)
+
+**Use for:** Converting power (W) to energy (kWh), flow rate to volume, etc.
+
+```yaml
+sensor:
+  - platform: integration
+    name: "Solar Energy"
+    source: sensor.solar_power
+    unit_prefix: k
+    unit_time: h
+    method: left
+    round: 2
+```
+
+**Methods:**
+- `left`: Uses previous value for interval (recommended for sparse data)
+- `right`: Uses new value for interval
+- `trapezoidal`: Averages previous and new (can overestimate with gaps)
+
+**Key behaviors:**
+- For solar/sensors with gaps, use `left` method
+- `max_sub_interval` forces updates even when source doesn't change
+
+**Common uses:**
+- Convert solar power (W) to energy production (kWh)
+- Convert water flow rate to total consumption
+- Convert gas flow to total usage
+
+---
+
+## State Storage
+
+### input_boolean
+
+**Use for:** Toggle switches for modes, flags, and conditions.
+
+```yaml
+input_boolean:
+  guest_mode:
+    name: "Guest Mode"
+    icon: mdi:account-group
+  vacation_mode:
+    name: "Vacation Mode"
+    icon: mdi:airplane
+```
+
+**Common uses:**
+- Guest mode (disable certain automations)
+- Vacation mode
+- Manual override flags
+- Feature toggles
+
+### input_number
+
+**Use for:** Storing numeric values that can be adjusted.
+
+```yaml
+input_number:
+  target_temperature:
+    name: "Target Temperature"
+    min: 15
+    max: 30
+    step: 0.5
+    unit_of_measurement: "°C"
+    mode: slider
+```
+
+**Modes:** `slider`, `box`
+
+**Common uses:**
+- User-adjustable thresholds
+- Target temperatures
+- Timer durations
+- Brightness levels
+
+### input_select
+
+**Use for:** Dropdown selection of predefined options.
+
+```yaml
+input_select:
+  hvac_mode:
+    name: "HVAC Mode"
+    options:
+      - "auto"
+      - "cool"
+      - "heat"
+      - "off"
+    icon: mdi:thermostat
+```
+
+**Common uses:**
+- Scene selection
+- Mode selection
+- Status tracking
+- Multi-state toggles
+
+### input_text
+
+**Use for:** Storing text strings.
+
+```yaml
+input_text:
+  notification_message:
+    name: "Custom Notification"
+    min: 0
+    max: 255
+    mode: text
+```
+
+**Modes:** `text`, `password`
+
+**Common uses:**
+- Custom messages
+- Temporary storage
+- User notes
+
+### input_datetime
+
+**Use for:** Storing date and/or time values.
+
+```yaml
+input_datetime:
+  morning_alarm:
+    name: "Morning Alarm"
+    has_time: true
+    has_date: false
+  next_vacation:
+    name: "Next Vacation"
+    has_date: true
+    has_time: false
+```
+
+**Common uses:**
+- Alarm times
+- Schedule times (wake-up, lights off)
+- Future dates (vacation, events)
+
+### input_button
+
+**Use for:** Triggering automations manually.
+
+```yaml
+input_button:
+  doorbell:
+    name: "Doorbell"
+    icon: mdi:bell
+```
+
+**Common uses:**
+- Manual triggers for automations
+- Dashboard buttons
+- Test triggers
+
+---
+
+## Counting and Timing
+
+### counter
+
+**Use for:** Tracking counts with increment/decrement/reset.
+
+**Instead of:**
+```yaml
+# WRONG - input_number with automation
+input_number:
+  coffee_count:
+    min: 0
+    max: 100
+automation:
+  - alias: "Increment coffee"
+    trigger: ...
+    action:
+      - action: input_number.set_value
+        data:
+          value: "{{ states('input_number.coffee_count') | int + 1 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Counter helper
+counter:
+  coffee_count:
+    name: "Coffees Today"
+    initial: 0
+    step: 1
+    minimum: 0
+    maximum: 100
+    restore: true
+```
+
+**Actions:** `counter.increment`, `counter.decrement`, `counter.reset`, `counter.set_value`
+
+**Key behaviors:**
+- `restore: true` preserves value across restarts
+- Respects min/max boundaries
+
+**Common uses:**
+- Daily counts (coffees, workouts)
+- Usage tracking
+- Sequential numbering
+
+---
+
+### timer
+
+**Use for:** Countdown timers that fire events when finished.
+
+**Instead of:**
+```yaml
+# WRONG - Delay in automation
+action:
+  - delay:
+      minutes: 5
+  - action: notify.mobile_app
+    data:
+      message: "Timer done!"
+```
+
+**Use this for pausable/restartable timers:**
+```yaml
+# RIGHT - Timer helper
+timer:
+  laundry:
+    name: "Laundry Timer"
+    duration: "01:00:00"
+    restore: true
+```
+
+**Actions:** `timer.start`, `timer.pause`, `timer.cancel`, `timer.finish`, `timer.change`
+
+**Events fired:**
+- `timer.started`
+- `timer.paused`
+- `timer.cancelled`
+- `timer.finished`
+- `timer.restarted`
+
+**Key behaviors:**
+- Can be started with custom duration: `timer.start` with `duration: "00:30:00"`
+- `restore: true` continues timer after restart
+- Can be controlled from dashboard
+
+**Common uses:**
+- Laundry/dryer reminders
+- Cooking timers
+- Activity timers with pause/resume
+
+---
+
+## Scheduling
+
+### schedule
+
+**Use for:** Weekly on/off schedules.
+
+```yaml
+schedule:
+  work_hours:
+    name: "Work Hours"
+    monday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    tuesday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    # ... etc
+```
+
+**Key behaviors:**
+- Creates a binary sensor that's `on` during scheduled times
+- Can have multiple blocks per day
+- Editable via UI
+
+**Instead of:**
+```yaml
+# WRONG - Template with weekday checks
+template:
+  - binary_sensor:
+      - name: "Work Hours"
+        state: >
+          {{ now().weekday() < 5 and 
+             now().hour >= 9 and 
+             now().hour < 17 }}
+```
+
+**Common uses:**
+- Work hours / business hours
+- Quiet hours
+- HVAC schedules
+- Lighting schedules
+
+---
+
+### time of day (tod)
+
+**Use for:** Binary sensor based on current time (sunrise/sunset or fixed times).
+
+```yaml
+binary_sensor:
+  - platform: tod
+    name: "Morning"
+    after: "06:00"
+    before: "12:00"
+    
+  - platform: tod
+    name: "Night Time"
+    after: sunset
+    after_offset: "01:00:00"
+    before: sunrise
+```
+
+**Common uses:**
+- Time-of-day modes (morning, afternoon, evening, night)
+- Daylight/darkness detection
+- Simple time-based conditions
+
+---
+
+## Entity Grouping
+
+### group
+
+**Use for:** Combining entities for collective state and control.
+
+```yaml
+group:
+  all_lights:
+    name: "All Lights"
+    entities:
+      - light.living_room
+      - light.bedroom
+      - light.kitchen
+    all: false  # ON if ANY member is on
+    
+  security_sensors:
+    name: "Security Sensors"
+    entities:
+      - binary_sensor.front_door
+      - binary_sensor.back_door
+      - binary_sensor.window
+    all: true  # ON only if ALL members are on
+```
+
+**Parameters:**
+- `all: false` (default): Group is ON if ANY member is ON (OR logic)
+- `all: true`: Group is ON only if ALL members are ON (AND logic)
+
+**Key behaviors:**
+- Groups inherit the domain of their members
+- Light groups can be controlled as a single entity
+- Binary sensor groups useful for "any door open" logic
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor for any-on logic
+template:
+  - binary_sensor:
+      - name: "Any Door Open"
+        state: >
+          {{ is_state('binary_sensor.front_door', 'on') or
+             is_state('binary_sensor.back_door', 'on') }}
+```
+
+**Common uses:**
+- All lights in an area
+- Any motion sensor active
+- All doors/windows closed
+- Group control in dashboards
+
+---
+
+## Decision Matrix
+
+| Need | Helper | Not |
+|------|--------|-----|
+| Average of multiple sensors | `min_max` (type: mean) | Template with math |
+| Sum of multiple sensors | `min_max` (type: sum) | Template with math |
+| Average over time | `statistics` | Template tracking history |
+| Rate of change | `derivative` | Template calculating delta |
+| On/off at threshold | `threshold` | Template binary sensor |
+| Consumption per period | `utility_meter` | Counter with reset automation |
+| Time in state | `history_stats` | Template tracking timestamps |
+| Power to energy | `integration` | Template approximating |
+| User toggle | `input_boolean` | - |
+| User number | `input_number` | - |
+| User selection | `input_select` | - |
+| Count events | `counter` | input_number + automation |
+| Countdown timer | `timer` | delay + input_datetime |
+| Weekly schedule | `schedule` | Template with weekday checks |
+| Time of day mode | `tod` | Template with time checks |
+| Any-on / all-on | `group` | Template binary sensor |

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -1,0 +1,572 @@
+# Template Guidelines
+
+This document covers when templates ARE the right choice in Home Assistant, and best practices for writing reliable templates.
+
+## Table of Contents
+1. [When Templates Are Appropriate](#when-templates-are-appropriate)
+2. [When to Avoid Templates](#when-to-avoid-templates)
+3. [Template Sensor Best Practices](#template-sensor-best-practices)
+4. [Automation Template Best Practices](#automation-template-best-practices)
+5. [Common Patterns](#common-patterns)
+6. [Error Handling](#error-handling)
+7. [Performance Considerations](#performance-considerations)
+
+---
+
+## When Templates Are Appropriate
+
+Templates are the RIGHT choice when:
+
+### 1. Dynamic Service Data
+
+You need to pass dynamic values to service calls based on entity states or trigger context.
+
+```yaml
+action:
+  - action: light.turn_on
+    target:
+      entity_id: light.bedroom
+    data:
+      brightness_pct: "{{ states('input_number.default_brightness') | int }}"
+      kelvin: "{{ 6500 if is_state('binary_sensor.daytime', 'on') else 2700 }}"
+```
+
+### 2. Dynamic Notification Messages
+
+Messages that include runtime information:
+
+```yaml
+action:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} has been {{ trigger.to_state.state }} 
+        for {{ trigger.for.total_seconds() | int // 60 }} minutes.
+```
+
+### 3. Processing Raw Data Sources
+
+MQTT, REST, and command line sensors often provide raw data that needs transformation:
+
+```yaml
+# REST sensor with JSON response
+rest:
+  - resource: "http://api.example.com/data"
+    sensor:
+      - name: "Temperature"
+        value_template: "{{ value_json.current.temperature }}"
+        unit_of_measurement: "°C"
+```
+
+### 4. Accessing Trigger Context
+
+Using `trigger.` variables in automations:
+
+```yaml
+action:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} changed from 
+        {{ trigger.from_state.state }} to {{ trigger.to_state.state }}
+```
+
+### 5. Complex String Formatting
+
+When you need formatted output that can't be achieved with native constructs:
+
+```yaml
+template:
+  - sensor:
+      - name: "Friendly Uptime"
+        state: >
+          {% set uptime = states('sensor.system_uptime') | float(0) %}
+          {% set days = (uptime // 86400) | int %}
+          {% set hours = ((uptime % 86400) // 3600) | int %}
+          {% set minutes = ((uptime % 3600) // 60) | int %}
+          {{ days }}d {{ hours }}h {{ minutes }}m
+```
+
+### 6. Attribute Extraction
+
+Creating sensors from entity attributes:
+
+```yaml
+template:
+  - sensor:
+      - name: "Current Song Artist"
+        state: "{{ state_attr('media_player.spotify', 'media_artist') }}"
+```
+
+### 7. Complex Conditional State
+
+When the state depends on multiple factors that can't be expressed with native conditions:
+
+```yaml
+template:
+  - sensor:
+      - name: "Comfort Level"
+        state: >
+          {% set temp = states('sensor.temperature') | float(20) %}
+          {% set humidity = states('sensor.humidity') | float(50) %}
+          {% if temp >= 20 and temp <= 24 and humidity >= 40 and humidity <= 60 %}
+            Comfortable
+          {% elif temp < 18 or humidity < 30 %}
+            Too Cold/Dry
+          {% elif temp > 26 or humidity > 70 %}
+            Too Hot/Humid
+          {% else %}
+            Acceptable
+          {% endif %}
+```
+
+### 8. Entity Iteration
+
+Processing multiple entities dynamically:
+
+```yaml
+template:
+  - sensor:
+      - name: "Open Windows Count"
+        state: >
+          {{ states.binary_sensor
+             | selectattr('attributes.device_class', 'eq', 'window')
+             | selectattr('state', 'eq', 'on')
+             | list
+             | count }}
+```
+
+### 9. Date/Time Calculations
+
+Time differences, formatting, and calculations:
+
+```yaml
+template:
+  - sensor:
+      - name: "Days Until Event"
+        state: >
+          {% set event_date = as_datetime(states('input_datetime.event')) %}
+          {% set today = now().replace(hour=0, minute=0, second=0, microsecond=0) %}
+          {{ ((event_date - today).days) }}
+        unit_of_measurement: "days"
+```
+
+---
+
+## When to Avoid Templates
+
+Do NOT use templates when a native alternative exists:
+
+| Don't Use Template | Use Native |
+|-------------------|------------|
+| `{{ states('x') in ['a', 'b'] }}` | `condition: state` with `state: ["a", "b"]` |
+| `{{ states('x') \| float > 25 }}` | `condition: numeric_state` with `above: 25` |
+| `{{ now().hour >= 9 }}` | `condition: time` with `after: "09:00:00"` |
+| `{{ is_state('sun.sun', 'below_horizon') }}` | `condition: sun` with `after: sunset` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger |
+| Template sensor summing values | `min_max` helper with `type: sum` |
+| Template binary sensor with threshold | `threshold` helper |
+| Template sensor averaging over time | `statistics` helper |
+
+See `automation-patterns.md` and `helper-selection.md` for comprehensive alternatives.
+
+---
+
+## Template Sensor Best Practices
+
+### Always Include unique_id
+
+```yaml
+template:
+  - sensor:
+      - name: "My Sensor"
+        unique_id: my_custom_sensor  # Enables UI customization
+        state: "{{ states('sensor.source') }}"
+```
+
+### Always Define Availability
+
+Prevent errors and unknown states:
+
+```yaml
+template:
+  - sensor:
+      - name: "Safe Sensor"
+        unique_id: safe_sensor
+        availability: >
+          {{ has_value('sensor.source_a') and 
+             has_value('sensor.source_b') }}
+        state: >
+          {{ states('sensor.source_a') | float + 
+             states('sensor.source_b') | float }}
+```
+
+### Use Appropriate Device Class
+
+Helps with unit conversion and graph display:
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Temperature"
+        device_class: temperature
+        unit_of_measurement: "°C"
+        state_class: measurement
+        state: "{{ states('sensor.raw_temp') | float / 10 }}"
+```
+
+### Use state_class for Statistics
+
+Required for long-term statistics:
+
+```yaml
+template:
+  - sensor:
+      - name: "Power Usage"
+        device_class: power
+        unit_of_measurement: "W"
+        state_class: measurement  # Enables statistics
+        state: "{{ states('sensor.amps') | float * 230 }}"
+```
+
+### Use Trigger-Based for Efficiency
+
+Trigger-based templates only update when sources change:
+
+```yaml
+template:
+  - trigger:
+      - trigger: state
+        entity_id: 
+          - sensor.temp_bedroom
+          - sensor.temp_living
+    sensor:
+      - name: "Average Temperature"
+        state: >
+          {% set temps = [
+            states('sensor.temp_bedroom') | float(0),
+            states('sensor.temp_living') | float(0)
+          ] %}
+          {{ (temps | sum / temps | count) | round(1) }}
+        unit_of_measurement: "°C"
+```
+
+**Benefits of trigger-based:**
+- Only evaluates when trigger fires (not on every state change)
+- Access to `trigger` variable
+- More efficient for complex templates
+
+---
+
+## Automation Template Best Practices
+
+### Use Shorthand Syntax
+
+For template conditions, use the shorthand:
+
+```yaml
+# Shorthand (preferred)
+condition:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+
+# Long form (equivalent but verbose)
+condition:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+### Use Multiline Strings
+
+For readability in complex templates:
+
+```yaml
+action:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {% if is_state('binary_sensor.door', 'on') %}
+          Warning: Door is open!
+        {% else %}
+          All secure.
+        {% endif %}
+```
+
+### Access Trigger Context Properly
+
+```yaml
+automation:
+  - trigger:
+      - trigger: state
+        entity_id: light.bedroom
+    action:
+      - action: notify.mobile_app
+        data:
+          message: >
+            Light changed from {{ trigger.from_state.state }} 
+            to {{ trigger.to_state.state }}
+            Entity: {{ trigger.entity_id }}
+            Brightness: {{ trigger.to_state.attributes.brightness | default('N/A') }}
+```
+
+---
+
+## Common Patterns
+
+### Safe State Access
+
+Always use `states()` function, not `states.sensor.x.state`:
+
+```yaml
+# GOOD - Returns 'unknown' if entity doesn't exist
+{{ states('sensor.temperature') }}
+
+# BAD - Errors if entity doesn't exist
+{{ states.sensor.temperature.state }}
+```
+
+### Safe Numeric Conversion
+
+```yaml
+# GOOD - Default value if conversion fails
+{{ states('sensor.temperature') | float(0) }}
+
+# BAD - Errors if state is 'unavailable' or 'unknown'
+{{ states('sensor.temperature') | float }}
+```
+
+### Check for Valid State
+
+```yaml
+{% if has_value('sensor.temperature') %}
+  Temperature is {{ states('sensor.temperature') }}°C
+{% else %}
+  Temperature unavailable
+{% endif %}
+```
+
+### Multiple States Check
+
+```yaml
+{% if is_state('light.a', 'on') and is_state('light.b', 'on') %}
+  Both lights on
+{% endif %}
+```
+
+### List of States
+
+```yaml
+{% if states('alarm_control_panel.home') in ['armed_home', 'armed_away', 'armed_night'] %}
+  Alarm is armed
+{% endif %}
+```
+
+### Attribute Access with Default
+
+```yaml
+{{ state_attr('light.bedroom', 'brightness') | default(0) }}
+```
+
+### Time Since State Change
+
+```yaml
+{% set last_changed = states.binary_sensor.motion.last_changed %}
+{% set seconds = (now() - last_changed).total_seconds() %}
+{{ (seconds / 60) | round(0) }} minutes ago
+```
+
+### Filter Entities by Attribute
+
+```yaml
+{% set open_windows = states.binary_sensor
+   | selectattr('attributes.device_class', 'defined')
+   | selectattr('attributes.device_class', 'eq', 'window')
+   | selectattr('state', 'eq', 'on')
+   | list %}
+{{ open_windows | count }} windows open
+```
+
+### Iterate with Index
+
+```yaml
+{% for light in states.light %}
+  {{ loop.index }}: {{ light.name }} is {{ light.state }}
+{% endfor %}
+```
+
+### Format Lists Human-Readable
+
+```yaml
+{% set items = ['apples', 'oranges', 'bananas'] %}
+{{ items[:-1] | join(', ') }} and {{ items[-1] }}
+{# Output: apples, oranges and bananas #}
+```
+
+---
+
+## Error Handling
+
+### Default Values
+
+```yaml
+# For numeric operations
+{{ states('sensor.x') | float(default=0) }}
+{{ states('sensor.x') | int(default=-1) }}
+
+# For attribute access
+{{ state_attr('light.x', 'brightness') | default(100) }}
+
+# For entire template failures
+{{ states('sensor.missing') | default('Unknown', true) }}
+```
+
+### Availability Template
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Value"
+        availability: "{{ has_value('sensor.input') }}"
+        state: "{{ states('sensor.input') | float * 2 }}"
+```
+
+### Check Before Use
+
+```yaml
+{% if is_state_attr('media_player.tv', 'is_volume_muted', false) %}
+  Volume: {{ state_attr('media_player.tv', 'volume_level') | float * 100 }}%
+{% else %}
+  Muted
+{% endif %}
+```
+
+### Handle None Attributes
+
+```yaml
+{% set attr = state_attr('sensor.x', 'some_attr') %}
+{% if attr is not none %}
+  Attribute value: {{ attr }}
+{% else %}
+  Attribute not available
+{% endif %}
+```
+
+---
+
+## Performance Considerations
+
+### Avoid Expensive Operations in Value Templates
+
+Templates in `value_template` for sensors update on EVERY state change of the source entity.
+
+```yaml
+# EXPENSIVE - Runs on every source sensor update
+sensor:
+  - platform: template
+    sensors:
+      expensive_sensor:
+        value_template: >
+          {% for entity in states %}  {# Iterates ALL entities #}
+            ...
+          {% endfor %}
+```
+
+### Use Trigger-Based Templates for Complex Logic
+
+```yaml
+# EFFICIENT - Only runs when specified triggers fire
+template:
+  - trigger:
+      - trigger: time_pattern
+        minutes: "/5"  # Every 5 minutes
+    sensor:
+      - name: "Complex Calculation"
+        state: >
+          {% set total = 0 %}
+          {% for sensor in states.sensor | selectattr('attributes.device_class', 'eq', 'energy') %}
+            {% set total = total + states(sensor.entity_id) | float(0) %}
+          {% endfor %}
+          {{ total }}
+```
+
+### Cache Complex Calculations
+
+If you need the same value in multiple places, create one template sensor and reference it:
+
+```yaml
+# ONE template sensor
+template:
+  - sensor:
+      - name: "House Occupancy Count"
+        state: >
+          {{ states.person | selectattr('state', 'eq', 'home') | list | count }}
+
+# Reference it elsewhere
+automation:
+  - condition: numeric_state
+    entity_id: sensor.house_occupancy_count
+    above: 0
+```
+
+### Use Variables for Repeated Access
+
+```yaml
+{% set temp = states('sensor.temperature') | float(0) %}
+{% set humidity = states('sensor.humidity') | float(0) %}
+
+{% if temp > 25 and humidity > 70 %}
+  Hot and humid
+{% elif temp > 25 %}
+  Hot (temp: {{ temp }}°C)
+{% endif %}
+```
+
+---
+
+## Quick Reference: Functions and Filters
+
+### State Functions
+
+| Function | Purpose |
+|----------|---------|
+| `states('entity_id')` | Get entity state (string) |
+| `state_attr('entity_id', 'attr')` | Get attribute value |
+| `is_state('entity_id', 'state')` | Check if entity has state |
+| `is_state_attr('entity_id', 'attr', 'value')` | Check attribute value |
+| `has_value('entity_id')` | True if not unknown/unavailable |
+
+### Common Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `float(default)` | Convert to float |
+| `int(default)` | Convert to int |
+| `round(precision)` | Round number |
+| `default(value)` | Provide fallback |
+| `timestamp_custom(format)` | Format timestamp |
+| `from_json` | Parse JSON string |
+| `to_json` | Convert to JSON string |
+| `regex_match(pattern)` | Regex match |
+| `regex_replace(find, replace)` | Regex replace |
+
+### Time Functions
+
+| Function | Purpose |
+|----------|---------|
+| `now()` | Current datetime |
+| `utcnow()` | Current UTC datetime |
+| `today_at('HH:MM')` | Today at specific time |
+| `as_timestamp(dt)` | Convert to Unix timestamp |
+| `as_datetime(ts)` | Convert from timestamp |
+| `as_timedelta(string)` | Parse duration string |
+
+### Collection Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `selectattr('attr', 'eq', 'value')` | Filter by attribute |
+| `rejectattr('attr', 'eq', 'value')` | Exclude by attribute |
+| `map(attribute='state')` | Extract attribute from list |
+| `list` | Convert to list |
+| `count` | Count items |
+| `first` / `last` | Get first/last item |
+| `sum` / `min` / `max` | Aggregate values |


### PR DESCRIPTION
## Summary
- Add 4 reference files covering automation patterns, device control, helper selection, and template guidelines
- Add compound examples file demonstrating multiple best practices working together
- Restructure SKILL.md as a lean routing document (98 lines) with decision workflow, anti-pattern table, and section-anchored reference index
- Deduplicate content: trim reference file examples that overlap with compound examples, condense SKILL.md anti-patterns from code blocks to a compact table
- Fix deprecated `has_value()` pattern in template-guidelines.md
- Align CONTRIBUTING.md and CLAUDE.md with the upstream Agent Skills spec (add `assets/` directory, relax description format)

## Details

**New reference files:**
| File | Lines | Covers |
|------|-------|--------|
| `references/automation-patterns.md` | 601 | Native conditions, trigger types, wait actions, automation modes, if/then vs choose, trigger IDs |
| `references/helper-selection.md` | 696 | min_max, statistics, derivative, threshold, utility_meter, history_stats, counter, timer, schedule, group + decision matrix |
| `references/template-guidelines.md` | 572 | When templates ARE appropriate, template sensor best practices, common patterns, error handling, performance |
| `references/device-control.md` | 417 | entity_id vs device_id, service call structure, ZHA vs Z2M button patterns, domain-specific patterns |
| `references/examples.yaml` | 221 | 5 compound automations combining multiple best practices |

**Total skill size:** 2,605 lines across 6 files (SKILL.md is 98 lines)

## Test plan
- [ ] `skills-ref validate skills/home-assistant-best-practices` passes
- [ ] SKILL.md description is under 1024 characters
- [ ] All file references in SKILL.md resolve correctly
- [ ] No content duplication between SKILL.md body and reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)