### PR TITLE
Add marketplace.json and update README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "home-assistant-skills",
+  "owner": {
+    "name": "homeassistant-ai",
+    "email": ""
+  },
+  "metadata": {
+    "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, and device control",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "home-assistant-skills",
+      "description": "Best practices for Home Assistant automations, helpers, scripts, and device controls",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/home-assistant-best-practices"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,27 +2,42 @@ name: Validate Skills
 
 on:
   pull_request:
-    paths:
-      - "skills/**"
   push:
     branches: [main]
-    paths:
-      - "skills/**"
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for skill changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base=${{ github.event.pull_request.base.sha }}
+          else
+            base=${{ github.event.before }}
+          fi
+          if git diff --name-only "$base" HEAD | grep -q '^skills/'; then
+            echo "skills_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skills_changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/setup-python@v5
+        if: steps.changes.outputs.skills_changed == 'true'
         with:
           python-version: "3.12"
 
       - name: Install skills-ref
+        if: steps.changes.outputs.skills_changed == 'true'
         run: pip install skills-ref
 
       - name: Validate all skills
+        if: steps.changes.outputs.skills_changed == 'true'
         run: |
           exit_code=0
           for skill_dir in skills/*/; do
@@ -32,3 +47,7 @@ jobs:
             fi
           done
           exit $exit_code
+
+      - name: No skill changes
+        if: steps.changes.outputs.skills_changed == 'false'
+        run: echo "No changes in skills/, skipping validation."

--- a/README.md
+++ b/README.md
@@ -1,20 +1,48 @@
 # Home Assistant Agent Skills
 
-Community-contributed [Agent Skills](https://agentskills.io) for Home Assistant teach AI agents domain expertise for configuring and controlling Home Assistant, following the open [Agent Skills standard](https://agentskills.io/specification).
+Community-contributed [Agent Skills](https://agentskills.io) for Home Assistant. These skills teach AI agents domain expertise for configuring and controlling Home Assistant, following the open [Agent Skills standard](https://agentskills.io/specification).
 
 ## Available Skills
 
 | Skill | Description |
 |---|---|
-| [home-assistant-best-practices](skills/home-assistant-best-practices/) | Best practices for configuring Home Assistant via MCP. Teaches native constructs and helper type selection. |
+| [home-assistant-best-practices](skills/home-assistant-best-practices/) | Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, and device control best practices. |
 
 ## Installation
+
+### Agent Skills installer
 
 ```bash
 npx skills add homeassistant-ai/skills
 ```
 
-Works with 26+ AI coding agents supporting the Agent Skills standard: Claude Code, Cursor, Copilot, VS Code, Gemini CLI, and others.
+Works with AI coding agents that support the [Agent Skills standard](https://agentskills.io): Claude Code, Cursor, Copilot, VS Code, Gemini CLI, and others. To update: `npx skills update`
+
+### Claude Code plugin
+
+```
+/plugin marketplace add homeassistant-ai/skills
+/plugin install home-assistant-skills@homeassistant-ai-skills
+```
+
+### Claude Desktop / claude.ai
+
+1. Download or clone this repository
+2. Zip the skill folder: `cd skills && zip -r home-assistant-best-practices.zip home-assistant-best-practices/`
+3. **Settings → Capabilities → Skills → Upload skill** → select the `.zip` file
+
+## Skill Contents
+
+The `home-assistant-best-practices` skill includes:
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Decision workflow and quick-reference routing |
+| `references/automation-patterns.md` | Native conditions, triggers, waits, automation modes |
+| `references/helper-selection.md` | Built-in helpers vs template sensors (with decision matrix) |
+| `references/template-guidelines.md` | When templates ARE the right choice |
+| `references/device-control.md` | Service calls, entity_id vs device_id, Zigbee buttons |
+| `references/examples.yaml` | Compound examples combining multiple best practices |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` for the Anthropic agent skills marketplace registration
- Update README with three installation methods: Agent Skills installer (`npx skills`), Claude Code plugin, and Claude Desktop/Web zip upload
- Add skill contents table documenting all reference files

## Test plan
- [ ] `marketplace.json` structure matches `anthropics/skills` reference format
- [ ] Plugin name in `marketplace.json` matches `plugin.json`
- [ ] All skill paths in `marketplace.json` resolve to existing directories
- [ ] `/plugin marketplace add homeassistant-ai/skills` works in Claude Code
- [ ] All file paths in README skill contents table are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)