### PR TITLE
Add safe refactoring workflow to prevent broken dashboards

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -2,23 +2,18 @@
 name: home-assistant-best-practices
 description: >
   Best practices for Home Assistant automations, helpers, scripts, and device controls.
-  
+
   TRIGGER THIS SKILL WHEN:
   - Creating or editing HA automations, scripts, or scenes
-  - Writing automation conditions or triggers
-  - Creating template sensors or binary sensors
-  - Using wait_template or wait_for_trigger
-  - Choosing between device triggers and state triggers
-  - Selecting automation modes (single/restart/queued/parallel)
+  - Choosing between template sensors and built-in helpers
+  - Writing or restructuring triggers, conditions, or automation modes
   - Setting up Zigbee button/remote automations (ZHA or Zigbee2MQTT)
-  - Deciding whether to use a built-in helper vs template sensor
-  
+  - Renaming entities or migrating device_id references to entity_id
+
   SYMPTOMS THAT TRIGGER THIS SKILL:
-  - Agent defaults to Jinja2 templates where native constructs exist
-  - Agent creates template sensors for simple aggregation (sum/min/max/mean)
-  - Agent uses template conditions instead of native state/numeric_state conditions
-  - Agent uses wait_template instead of wait_for_trigger
+  - Agent uses Jinja2 templates where native conditions, triggers, or helpers exist
   - Agent uses device_id instead of entity_id in triggers/actions
+  - Agent modifies entity IDs or config objects without checking all consumers
   - Agent chooses wrong automation mode (e.g., single for motion lights)
 ---
 
@@ -29,6 +24,12 @@ description: >
 ## Decision Workflow
 
 Follow this sequence when creating any automation:
+
+### 0. Gate: modifying existing config?
+
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
+
+Steps 1-5 below apply to new config or pattern evaluation.
 
 ### 1. Check for native condition/trigger
 Before writing any template, check `references/automation-patterns.md` for native alternatives.
@@ -82,6 +83,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
 | Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
+| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, and scenes silently | `references/safe-refactoring.md#entity-renames` |
 
 ---
 
@@ -91,6 +93,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -38,7 +38,7 @@ Before writing any template, check `references/automation-patterns.md` for nativ
 - `{{ states('x') | float > 25 }}` → `numeric_state` condition with `above: 25`
 - `{{ is_state('x', 'on') and is_state('y', 'on') }}` → `condition: and` with state conditions
 - `{{ now().hour >= 9 }}` → `condition: time` with `after: "09:00:00"`
-- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger
+- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see `references/safe-refactoring.md#trigger-restructuring`)
 
 ### 2. Check for built-in helper
 Before creating a template sensor, check `references/helper-selection.md`.
@@ -78,7 +78,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Anti-pattern | Use instead | Why | Reference |
 |---|---|---|---|
 | `condition: template` with `float > 25` | `condition: numeric_state` | Validated at load, not runtime | `references/automation-patterns.md#native-conditions` |
-| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* | `references/automation-patterns.md#wait-actions` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see `references/safe-refactoring.md#trigger-restructuring` for semantic differences) | `references/automation-patterns.md#wait-actions` |
 | `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | `references/device-control.md#entity-id-vs-device-id` |
 | `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -24,7 +24,7 @@ Search every component type that references entity IDs. Do not limit searches to
 | Component | How to search |
 |-----------|---------------|
 | Automations | `ha_deep_search(query="entity_id")` or grep `automations.yaml` |
-| Dashboards | grep `.storage/lovelace*`, `ui-lovelace.yaml` |
+| Dashboards | `ha_dashboard_find_card(entity_id="...")` or grep `.storage/lovelace*`, `ui-lovelace.yaml` |
 | Scripts | grep `scripts.yaml` |
 | Scenes | grep `scenes.yaml` |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -1,0 +1,92 @@
+# Safe Refactoring Workflow
+
+Follow this workflow whenever you modify existing Home Assistant configuration: renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations.
+
+**Core rule:** Search all consumers BEFORE changing anything. Verify zero stale references AFTER.
+
+---
+
+## Universal Workflow
+
+### Step 1: Identify the full scope of change
+
+Answer three questions before touching anything:
+
+1. **What changes?** Entity ID, automation structure, sensor type, or trigger semantics.
+2. **What sibling entities share the same device?** Query the device to list every entity it owns (battery sensor, update entity, diagnostic button). Plan changes for all siblings together.
+   - *Tool hint:* `ha_get_device(entity_id="...")` if available, or inspect Settings > Devices.
+3. **Rename one entity or all device entities?** Devices bundle 2-6 entities. Renaming the primary but leaving siblings with the old naming scheme creates inconsistency.
+
+### Step 2: Search ALL consumers
+
+Search every component type that references entity IDs. Do not limit searches to the component you are editing.
+
+| Component | How to search |
+|-----------|---------------|
+| Automations | `ha_deep_search(query="entity_id")` or grep `automations.yaml` / `.storage/automations` |
+| Dashboards | `ha_dashboard_find_card(entity_id="...")` or grep `.storage/lovelace*` |
+| Scripts | grep `scripts.yaml` / `.storage/scripts` |
+| Scenes | grep `scenes.yaml` / `.storage/scenes` |
+| Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
+
+Record every location found. This list becomes your update checklist for Step 4.
+
+### Step 3: Make the change
+
+Rename the entity, replace the template sensor, or restructure the automation.
+
+### Step 4: Update every consumer
+
+Work through each location from your Step 2 checklist. Update every reference to the new entity ID, helper entity, or automation structure.
+
+### Step 5: Verify
+
+1. **Search for the OLD identifier** across all component types. Expect zero results.
+   - *Tool hint:* `ha_search_entities(query="old_name")` or grep all config files.
+2. **Search for the NEW identifier** to confirm all expected locations reference it.
+3. **Reload or check dashboards** if entity IDs changed.
+4. **If stale references remain that you cannot update**, rename the entity back to its original ID to restore functionality, then report the blocking locations to the user.
+
+---
+
+## Entity Renames
+
+Additional requirements beyond the universal workflow:
+
+**Device-sibling discovery (Step 1):**
+HA devices bundle multiple entities. A smart plug might expose `switch.*`, `sensor.*_energy`, and `update.*`. A multi-sensor exposes motion, temperature, illuminance, and battery entities. Rename all siblings to match.
+
+Example — renaming a smart plug's entities from manufacturer defaults to room-based names:
+
+| Domain | Old entity ID | New entity ID |
+|---|---|---|
+| switch | `switch.shelly_plug_s_abc123` | `switch.office_heater` |
+| sensor | `sensor.shelly_plug_s_abc123_energy` | `sensor.office_heater_energy` |
+| update | `update.shelly_plug_s_abc123` | `update.office_heater` |
+
+**Dashboard reference locations (Step 2):**
+Dashboard cards reference entities in multiple places: `entity:` field, `tap_action` targets, `hold_action` targets, conditional card conditions, and template card Jinja2 blocks. Search all of these.
+
+---
+
+## Helper Replacements
+
+When replacing a template sensor with a built-in helper (`min_max`, `threshold`, `derivative`):
+
+**New entity ID (Step 1):**
+The helper creates a new entity with a different entity_id. The old template sensor's entity_id stops existing. Update every consumer of the old entity_id to reference the new one.
+
+**Test equivalence (Step 5):**
+Verify the new helper produces the same values as the old template sensor. Check units, precision, and unavailable-state handling.
+
+---
+
+## Trigger Restructuring
+
+When converting `device_id` triggers to `entity_id` triggers, or replacing `wait_template` with `wait_for_trigger`:
+
+**Behavioral equivalence (Step 1):**
+`wait_for_trigger` waits for a state *change*; `wait_template` polls for *current state*. These differ when the target state is already true at wait start: `wait_for_trigger` blocks indefinitely, `wait_template` returns immediately.
+
+**Automation callers (Step 2):**
+Search for scripts or other automations that call the automation you are restructuring via `automation.trigger` or `automation.turn_on`. Renaming or splitting an automation changes its entity_id and breaks these callers.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -23,10 +23,10 @@ Search every component type that references entity IDs. Do not limit searches to
 
 | Component | How to search |
 |-----------|---------------|
-| Automations | `ha_deep_search(query="entity_id")` or grep `automations.yaml` / `.storage/automations` |
-| Dashboards | `ha_dashboard_find_card(entity_id="...")` or grep `.storage/lovelace*` |
-| Scripts | grep `scripts.yaml` / `.storage/scripts` |
-| Scenes | grep `scenes.yaml` / `.storage/scenes` |
+| Automations | `ha_deep_search(query="entity_id")` or grep `automations.yaml` |
+| Dashboards | grep `.storage/lovelace*`, `ui-lovelace.yaml` |
+| Scripts | grep `scripts.yaml` |
+| Scenes | grep `scenes.yaml` |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
 
 Record every location found. This list becomes your update checklist for Step 4.
@@ -60,12 +60,17 @@ Example — renaming a smart plug's entities from manufacturer defaults to room-
 
 | Domain | Old entity ID | New entity ID |
 |---|---|---|
-| switch | `switch.shelly_plug_s_abc123` | `switch.office_heater` |
-| sensor | `sensor.shelly_plug_s_abc123_energy` | `sensor.office_heater_energy` |
-| update | `update.shelly_plug_s_abc123` | `update.office_heater` |
+| switch | `switch.shellyplug_s_a1b2c3d4e5f6` | `switch.office_heater` |
+| sensor | `sensor.shellyplug_s_a1b2c3d4e5f6_energy` | `sensor.office_heater_energy` |
+| update | `update.shellyplug_s_a1b2c3d4e5f6` | `update.office_heater` |
 
 **Dashboard reference locations (Step 2):**
-Dashboard cards reference entities in multiple places: `entity:` field, `tap_action` targets, `hold_action` targets, conditional card conditions, and template card Jinja2 blocks. Search all of these.
+Dashboard cards reference entities in multiple places. Search all of these:
+
+- `entity:` field
+- `tap_action` and `hold_action` targets
+- Conditional card conditions
+- Template card Jinja2 blocks
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds change management guidance to `home-assistant-best-practices` after an incident where renaming an entity broke dashboard cards and missed sibling device entities
- Introduces a Step 0 gate in the Decision Workflow that routes existing-config modifications to a new `references/safe-refactoring.md` safety workflow
- Consolidates description triggers (8 to 5) and symptoms (6 to 4) while adding refactoring-specific activation conditions

## What changed

**SKILL.md (101 lines, was 99):**
- Tightened `description` frontmatter with new trigger: "Renaming entities or migrating device_id references"
- New symptom: "Agent modifies entity IDs or config objects without checking all consumers"
- Step 0 gate scoped to changes affecting entity IDs or cross-component references
- New anti-pattern row for unverified entity ID modifications
- `safe-refactoring.md` added as first entry in reference files table

**New: references/safe-refactoring.md (92 lines):**
- Universal 5-step workflow: identify scope, search all consumers, change, update, verify
- Entity rename checklist: device-sibling discovery, dashboard sub-location search
- Helper replacement checklist: new entity ID warning, equivalence testing
- Trigger restructuring checklist: `wait_for_trigger` vs `wait_template` semantics
- Catch-all row for external consumers (AppDaemon, Node-RED, Pyscript)
- Rollback guidance if stale references can't be resolved

## Context

Root cause analysis: `rca_broken._dashboard.md`  
Design decisions: `rca_analysis_and_conclusions.md`

The skill told agents *what* correct config looks like but not *how* to safely get there from existing config. These changes close that gap.

## Test plan

- [ ] `skills-ref validate skills/home-assistant-best-practices` passes
- [ ] SKILL.md under 500 lines (101)
- [ ] safe-refactoring.md anchor links match SKILL.md references (`#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`)
- [ ] Step 0 gate triggers on entity rename scenario but not on trivial automation edits
- [ ] Replay RCA timeline against updated skill — all five failures addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)