### PR TITLE
Add semver versioning for skills with CI enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-rca.md
+++ b/.github/ISSUE_TEMPLATE/skill-rca.md
@@ -23,6 +23,7 @@ Write "N/A" for any section that is irrelevant.
 ## 1. Context
 
 - **Skill name:**  <!-- e.g. home-assistant-best-practices -->
+- **Skill version:**  <!-- from the metadata.version field in SKILL.md frontmatter -->
 - **What the user originally asked you to do:**
 
 ## 2. Timeline

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -48,6 +48,31 @@ jobs:
           done
           exit $exit_code
 
+      - name: Enforce version bump
+        if: steps.changes.outputs.skills_changed == 'true' && github.event_name == 'pull_request'
+        run: |
+          base=${{ github.event.pull_request.base.sha }}
+          exit_code=0
+          changed_skills=$(git diff --name-only "$base" HEAD -- 'skills/' | cut -d'/' -f1-2 | sort -u)
+          for skill_dir in $changed_skills; do
+            skill_md="${skill_dir}/SKILL.md"
+            if [ ! -f "$skill_md" ]; then
+              continue
+            fi
+            head_version=$(grep -A1 '^metadata:' "$skill_md" | grep 'version:' | sed 's/.*version:[[:space:]]*"\?\([^"]*\)"\?/\1/')
+            base_version=$(git show "${base}:${skill_md}" 2>/dev/null | grep -A1 '^metadata:' | grep 'version:' | sed 's/.*version:[[:space:]]*"\?\([^"]*\)"\?/\1/')
+            if [ -z "$head_version" ]; then
+              echo "FAIL: ${skill_md} is missing metadata.version"
+              exit_code=1
+            elif [ "$head_version" = "$base_version" ]; then
+              echo "FAIL: ${skill_md} content changed but metadata.version was not bumped (still ${head_version})"
+              exit_code=1
+            else
+              echo "OK: ${skill_md} version bumped ${base_version} -> ${head_version}"
+            fi
+          done
+          exit $exit_code
+
       - name: No skill changes
         if: steps.changes.outputs.skills_changed == 'false'
         run: echo "No changes in skills/, skipping validation."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ skills/
 ### SKILL.md requirements
 
 - **YAML frontmatter** with `name` (letters, numbers, hyphens only; 64 chars max) and `description` (1024 chars max).
+- **`metadata.version`** using [semver](https://semver.org/) (e.g. `"1.0.0"`). Bump the version in every PR that changes skill content. CI enforces this.
 - **`description`** in third person. Describe what the skill does and when to use it. Include keywords that help agents match tasks. Don't summarize the skill's workflow.
 - **Body** under 500 lines. Split into reference files if approaching this limit.
 - **Reference files** one level deep from SKILL.md—no nested references.

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -15,6 +15,8 @@ description: >
   - Agent uses device_id instead of entity_id in triggers/actions
   - Agent modifies entity IDs or config objects without checking all consumers
   - Agent chooses wrong automation mode (e.g., single for motion lights)
+metadata:
+  version: "1.0.0"
 ---
 
 # Home Assistant Best Practices


### PR DESCRIPTION
## Summary
- Add `metadata.version` (semver) to skill frontmatter, per the Agent Skills spec
- Add CI step that fails PRs changing skill content without a version bump
- Add "Skill version" field to the RCA issue template
- Document versioning requirement in CONTRIBUTING.md

## Changes
- `skills/home-assistant-best-practices/SKILL.md` — set initial version `1.0.0`
- `.github/workflows/validate-skills.yml` — new "Enforce version bump" step (PR-only)
- `.github/ISSUE_TEMPLATE/skill-rca.md` — added version field to Context section
- `CONTRIBUTING.md` — added `metadata.version` requirement

## Test plan
- [ ] Verify CI passes on this PR (no version bump needed since base has no version yet)
- [ ] Open a test PR that changes skill content without bumping version — CI should fail
- [ ] Open a test PR that changes skill content with a version bump — CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)