### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/homeassistant-ai/skills/security/code-scanning/2](https://github.com/homeassistant-ai/skills/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block for the workflow or job that grants only the minimal required scopes to `GITHUB_TOKEN`. In this workflow, the job only needs to read repository contents (to clone and run `git diff`/`git show`) and does not interact with issues, PRs, or other resources, so `contents: read` is sufficient.

The best fix without changing functionality is to add a workflow-level `permissions` block near the top of `.github/workflows/validate-skills.yml`, right after the `name:` or `on:` section, setting `contents: read`. This will apply to all jobs (there is only one job, `validate`) and will ensure the token cannot write to the repository or other resources unless explicitly allowed in the future. No additional imports or methods are required because this is purely a configuration change in the workflow YAML.

Concretely, modify `.github/workflows/validate-skills.yml` by inserting:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section (for clarity and common style) or directly after `name:`; both are valid, but we will place it after `on:` to keep triggers and permissions grouped before the job definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
