### PR TITLE
Improve README clarity for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-agentskills.io-blue)](https://agentskills.io)
 
-Community-contributed [Agent Skills](https://agentskills.io) for Home Assistant. These skills teach AI agents domain expertise for configuring and controlling Home Assistant, following the open [Agent Skills standard](https://agentskills.io/specification).
+An **Agent Skill** is a plugin that teaches AI coding agents best practices for a specific technology, delivered as a portable Markdown knowledge pack.
 
-## Available Skills
+This repository provides an Agent Skill for Home Assistant, following the open [Agent Skills standard](https://agentskills.io/specification). Install a skill and your agent gains Home Assistant best practices that persist across sessions.
 
-| Skill | Description |
-|---|---|
-| [home-assistant-best-practices](skills/home-assistant-best-practices/) | Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, device control best practices, and safe refactoring. |
+## Included Skill
+
+**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, device control best practices, and safe refactoring.
 
 ## Installation
 
 ### Agent Skills installer
+
+Requires [Node.js 18+](https://nodejs.org/).
 
 ```bash
 npx skills add homeassistant-ai/skills
@@ -23,10 +25,16 @@ Works with AI coding agents that support the [Agent Skills standard](https://age
 
 ### Claude Code plugin
 
+Run each command separately inside Claude Code:
+
 ```
 /plugin marketplace add homeassistant-ai/skills
+```
+```
 /plugin install home-assistant-skills@homeassistant-ai-skills
 ```
+
+Restart Claude Code after installation for the skill to take effect.
 
 ### Claude Desktop / claude.ai
 
@@ -44,7 +52,7 @@ The `home-assistant-best-practices` skill includes:
 | `references/safe-refactoring.md` | Safe workflow for renaming entities, replacing helpers, restructuring automations |
 | `references/automation-patterns.md` | Native conditions, triggers, waits, automation modes |
 | `references/helper-selection.md` | Built-in helpers vs template sensors (with decision matrix) |
-| `references/template-guidelines.md` | When templates ARE the right choice |
+| `references/template-guidelines.md` | When templates are the right choice |
 | `references/device-control.md` | Service calls, entity_id vs device_id, Zigbee buttons |
 | `references/examples.yaml` | Compound examples combining multiple best practices |
 


### PR DESCRIPTION
## Summary

- Add a one-sentence definition of "Agent Skill" for readers unfamiliar with the concept
- Move Node.js 18+ prerequisite inline with the `npx skills` installer instead of a separate section
- Clarify Claude Code plugin installation: split commands into separate blocks, add restart note
- Replace "Available Skills" table with single-skill format to match current repo state
- Minor prose tightening (positive form, remove shouted caps emphasis)

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links resolve (Agent Skills standard, Node.js, skill folder, CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)