### PR TITLE
Fix plugin manifest conflicts and add plugin validation CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,11 +12,7 @@
     {
       "name": "home-assistant-skills",
       "description": "Best practices for Home Assistant automations, helpers, scripts, and device controls",
-      "source": "./",
-      "strict": false,
-      "skills": [
-        "./skills/home-assistant-best-practices"
-      ]
+      "source": "./"
     }
   ]
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize all text files to LF in the repo
+* text=auto eol=lf

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,0 +1,27 @@
+name: Validate Plugin Manifests
+
+on:
+  pull_request:
+    paths: [".claude-plugin/**"]
+  push:
+    branches: [main]
+    paths: [".claude-plugin/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate plugin manifests
+        run: claude plugin validate .


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                        
  - Remove redundant `strict` and `skills` fields from `marketplace.json` that conflicted with `plugin.json`                                                                                                                                                                                                        
  - Add CI workflow to validate plugin manifests using `claude plugin validate` on changes to `.claude-plugin/`                                                                                                                                                                                                     
  - Add `.gitattributes` to enforce LF line endings repo-wide                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
Closes #14