### PR TITLE
docs(template-guidelines): clarify state_class requirement and add YA…

### DIFF
--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -220,11 +220,12 @@ template:
         state: "{{ states('sensor.raw_temp') | float / 10 }}"
 ```
 
-### Use state_class for Statistics (Mandatory for Numeric Sensors)
+### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
 
-**If `unit_of_measurement` is set, `state_class` MUST also be set.** Without it, HA writes
-no long-term statistics — the sensor will not appear in `statistics_meta` at all and will be
-invisible to the Energy Dashboard and History graphs.
+**If long-term statistics are needed, set `state_class`.** Without it, HA writes no
+long-term statistics — the sensor will not appear in `statistics_meta` and will be invisible
+to the Energy Dashboard and History graphs. `state_class` is optional for diagnostic or
+one-shot sensors where statistics are not required.
 (Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
 
 Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
@@ -235,7 +236,7 @@ template:
       - name: "Power Usage"
         device_class: power
         unit_of_measurement: "W"
-        state_class: measurement  # REQUIRED – without this, no long-term statistics are written
+        state_class: measurement  # enables long-term statistics (omit if not needed)
         state: "{{ states('sensor.amps') | float * 230 }}"
 ```
 

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -223,10 +223,14 @@ template:
 ### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
 
 **If long-term statistics are needed, set `state_class`.** Without it, HA writes no
-long-term statistics — the sensor will not appear in `statistics_meta` and will be invisible
-to the Energy Dashboard and History graphs. `state_class` is optional for diagnostic or
-one-shot sensors where statistics are not required.
+long-term statistics — the sensor will not appear in `statistics_meta` or in History graphs.
+`state_class` is optional for diagnostic or one-shot sensors where statistics are not required.
 (Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
+
+> **Energy Dashboard note:** `state_class` alone is not sufficient for Energy Dashboard
+> visibility. The sensor also needs `device_class: energy` (or `power`, `gas`, etc.) to
+> appear as a selectable source. A sensor with `state_class` but no matching `device_class`
+> will have long-term statistics but will not appear in the Energy Dashboard configuration.
 
 Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
 
@@ -274,11 +278,13 @@ template:
 uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
 and no warnings — but all official HA docs now use plural. Write new templates in plural form.
 
-**Consolidate same-type entities in one block.** All `sensor` or `binary_sensor` entries of
-the same type belong in a single block, not in separate blocks per entity:
+**Consolidate state-based entities of the same type in one block.** Multiple state-based
+`sensor` or `binary_sensor` entries without individual triggers belong in a single block —
+not in separate blocks per entity. Trigger-based blocks (with their own `triggers:` section)
+must be separate regardless of entity type, since each block defines its own trigger context:
 
 ```yaml
-# CORRECT — one block, multiple entries:
+# CORRECT — state-based sensors: one block, multiple entries:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -288,7 +294,7 @@ template:
         unique_id: motion_room_b
         state: "{{ ... }}"
 
-# AVOID — separate block per entity:
+# AVOID — state-based sensors split across separate blocks:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -299,6 +305,10 @@ template:
         unique_id: motion_room_b_avoid
         state: "{{ ... }}"
 ```
+
+> **Trigger-based blocks are always separate** — a block with `triggers:` defines its own
+> update context and cannot share a block with entries of a different trigger configuration.
+> Only consolidate entries that share the same trigger context (or are all state-based).
 
 **Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
 
@@ -532,7 +542,7 @@ sensor:
 ```yaml
 # EFFICIENT - Only runs when specified triggers fire
 template:
-  - trigger:
+  - triggers:
       - trigger: time_pattern
         minutes: "/5"  # Every 5 minutes
     sensor:

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -220,9 +220,14 @@ template:
         state: "{{ states('sensor.raw_temp') | float / 10 }}"
 ```
 
-### Use state_class for Statistics
+### Use state_class for Statistics (Mandatory for Numeric Sensors)
 
-Required for long-term statistics:
+**If `unit_of_measurement` is set, `state_class` MUST also be set.** Without it, HA writes
+no long-term statistics — the sensor will not appear in `statistics_meta` at all and will be
+invisible to the Energy Dashboard and History graphs.
+(Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
+
+Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
 
 ```yaml
 template:
@@ -230,7 +235,7 @@ template:
       - name: "Power Usage"
         device_class: power
         unit_of_measurement: "W"
-        state_class: measurement  # Enables statistics
+        state_class: measurement  # REQUIRED – without this, no long-term statistics are written
         state: "{{ states('sensor.amps') | float * 230 }}"
 ```
 
@@ -240,7 +245,7 @@ Trigger-based templates only update when sources change:
 
 ```yaml
 template:
-  - trigger:
+  - triggers:                    # Recommended plural form (HA 2024.10+)
       - trigger: state
         entity_id: 
           - sensor.temp_bedroom
@@ -254,12 +259,56 @@ template:
           ] %}
           {{ (temps | sum / temps | count) | round(1) }}
         unit_of_measurement: "°C"
+        state_class: measurement
 ```
 
 **Benefits of trigger-based:**
 - Only evaluates when trigger fires (not on every state change)
 - Access to `trigger` variable
 - More efficient for complex templates
+
+### YAML Block Structure Conventions (HA 2024.10+)
+
+**Use plural keys in trigger-based template blocks.** Since HA 2024.10 the recommended syntax
+uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
+and no warnings — but all official HA docs now use plural. Write new templates in plural form.
+
+**Consolidate same-type entities in one block.** All `sensor` or `binary_sensor` entries of
+the same type belong in a single block, not in separate blocks per entity:
+
+```yaml
+# CORRECT — one block, multiple entries:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+        unique_id: motion_room_a
+        state: "{{ ... }}"
+      - name: "Motion Room B"
+        unique_id: motion_room_b
+        state: "{{ ... }}"
+
+# AVOID — separate block per entity:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+  - binary_sensor:
+      - name: "Motion Room B"
+```
+
+**Use 4-space indentation for list items under block keys.** Official HA template docs consistently
+use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid but creates
+visual ambiguity:
+
+```yaml
+# CORRECT — 4-space indent, matches official docs:
+- binary_sensor:
+    - name: "My Sensor"
+      state: "{{ ... }}"
+
+# VALID but harder to read — avoid:
+- binary_sensor:
+  - name: "My Sensor"
+```
 
 ---
 

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -291,21 +291,23 @@ template:
 template:
   - binary_sensor:
       - name: "Motion Room A"
+        unique_id: motion_room_a_avoid
+        state: "{{ ... }}"
   - binary_sensor:
       - name: "Motion Room B"
+        unique_id: motion_room_b_avoid
+        state: "{{ ... }}"
 ```
 
-**Prefer 4-space indentation for list items under block keys.** Official HA template docs
-consistently use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid
-and works without issues, but 4-space improves visual alignment with the block key:
+**Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
 
 ```yaml
-# Preferred — 4-space indent, matches official docs:
+# Standard — 2-space indent per level (HA Style Guide, matches official docs):
 - binary_sensor:
     - name: "My Sensor"
       state: "{{ ... }}"
 
-# Also valid — 2-space indent is YAML-correct, just less visually distinct:
+# Non-standard — compact notation (valid YAML, but absent from official HA docs):
 - binary_sensor:
   - name: "My Sensor"
 ```

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -295,17 +295,17 @@ template:
       - name: "Motion Room B"
 ```
 
-**Use 4-space indentation for list items under block keys.** Official HA template docs consistently
-use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid but creates
-visual ambiguity:
+**Prefer 4-space indentation for list items under block keys.** Official HA template docs
+consistently use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid
+and works without issues, but 4-space improves visual alignment with the block key:
 
 ```yaml
-# CORRECT — 4-space indent, matches official docs:
+# Preferred — 4-space indent, matches official docs:
 - binary_sensor:
     - name: "My Sensor"
       state: "{{ ... }}"
 
-# VALID but harder to read — avoid:
+# Also valid — 2-space indent is YAML-correct, just less visually distinct:
 - binary_sensor:
   - name: "My Sensor"
 ```


### PR DESCRIPTION
…ML structure conventions

Fixes #17

- Strengthen state_class section: clarify it is **mandatory** (not just recommended) when unit_of_measurement is set. Without state_class, HA writes no long-term statistics and the sensor is absent from statistics_meta. Verified on HA 2026.3.
- Add device_class mirror guidance: mirror device_class from source sensor where applicable.
- Update trigger-based example to use recommended plural syntax (triggers:) from HA 2024.10+. Singular trigger: / action: remain valid — no deprecation, no warnings.
- Add new section "YAML Block Structure Conventions (HA 2024.10+)" covering:
  - Plural keys (triggers: / actions:) as recommended style
  - Consolidate same-type entities in one block instead of separate blocks per entity
  - 4-space indentation under block keys (matches official HA docs)