### PR TITLE
Prefer Template Helper over YAML template (home-assistant-best-practices v1.1.0)

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: home-assistant-best-practices
 description: >
-  Best practices for Home Assistant automations, helpers, scripts, and device controls.
+  Best practices for Home Assistant automations, helpers, scripts, device controls, and
+  Lovelace dashboard configuration.
 
   TRIGGER THIS SKILL WHEN:
   - Creating or editing HA automations, scripts, or scenes
@@ -9,14 +10,17 @@ description: >
   - Writing or restructuring triggers, conditions, or automation modes
   - Setting up Zigbee button/remote automations (ZHA or Zigbee2MQTT)
   - Renaming entities or migrating device_id references to entity_id
+  - Configuring Lovelace dashboard cards and selecting the right sensor or helper to feed them
 
   SYMPTOMS THAT TRIGGER THIS SKILL:
   - Agent uses Jinja2 templates where native conditions, triggers, or helpers exist
   - Agent uses device_id instead of entity_id in triggers/actions
   - Agent modifies entity IDs or config objects without checking all consumers
   - Agent chooses wrong automation mode (e.g., single for motion lights)
+  - Agent hard-codes min/max values or picks a raw sensor when a derived helper is more
+    appropriate for a dashboard card
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Home Assistant Best Practices
@@ -42,7 +46,7 @@ Before writing any template, check `references/automation-patterns.md` for nativ
 - `{{ now().hour >= 9 }}` → `condition: time` with `after: "09:00:00"`
 - `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see `references/safe-refactoring.md#trigger-restructuring`)
 
-### 2. Check for built-in helper
+### 2. Check for built-in helper or Template Helper
 Before creating a template sensor, check `references/helper-selection.md`.
 
 **Common substitutions:**
@@ -51,6 +55,11 @@ Before creating a template sensor, check `references/helper-selection.md`.
 - Rate of change → `derivative` integration
 - Cross threshold detection → `threshold` integration
 - Consumption tracking → `utility_meter` helper
+
+**If no built-in helper fits, use a Template Helper — not YAML.**
+Create it via the HA config flow (MCP tool or API) or via the UI:
+Settings → Devices & Services → Helpers → Create Helper → Template.
+Only write `template:` YAML if explicitly requested or if neither path is available.
 
 ### 3. Select correct automation mode
 Default `single` mode is often wrong. See `references/automation-patterns.md#automation-modes`.
@@ -86,6 +95,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
 | Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
 | Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, and scenes silently | `references/safe-refactoring.md#entity-renames` |
+| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
 
 ---
 

--- a/skills/home-assistant-best-practices/evals/evals.json
+++ b/skills/home-assistant-best-practices/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "home-assistant-best-practices",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "vacuum-last-clean",
+      "prompt": "create a sensor that shows my vacuum's last clean time in a human-readable format",
+      "expected_output": "Recommends creating a Template Helper (via UI or config flow/MCP), NOT writing a template: block in configuration.yaml",
+      "assertions": [
+        {
+          "id": "recommends_template_helper",
+          "description": "Response recommends Template Helper (UI or API/MCP) rather than YAML template: block"
+        },
+        {
+          "id": "no_yaml_template_first",
+          "description": "Response does NOT lead with or exclusively suggest writing template: YAML in configuration.yaml"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "media-player-song",
+      "prompt": "I want a sensor showing my media player's current song title",
+      "expected_output": "Recommends creating a Template Helper (via UI or config flow/MCP) for attribute extraction, not YAML",
+      "assertions": [
+        {
+          "id": "recommends_template_helper",
+          "description": "Response recommends Template Helper (UI or API/MCP) rather than YAML template: block"
+        },
+        {
+          "id": "no_yaml_template_first",
+          "description": "Response does NOT lead with or exclusively suggest writing template: YAML in configuration.yaml"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "avg-temperature",
+      "prompt": "create a sensor that averages my 3 room temperature sensors",
+      "expected_output": "Recommends min_max helper (built-in integration), NOT Template Helper or YAML template",
+      "assertions": [
+        {
+          "id": "recommends_min_max",
+          "description": "Response recommends the min_max integration helper with type: mean"
+        },
+        {
+          "id": "no_template_needed",
+          "description": "Response does NOT recommend a template sensor (YAML or UI helper) as the primary solution"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -1,3 +1,7 @@
+> **Prefer a Template Helper over YAML.**
+> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or the UI: Settings → Devices & Services → Helpers → Create Helper → Template.
+> Use `template:` YAML only when explicitly requested or when neither programmatic nor UI access is available.
+
 # Template Guidelines
 
 This document covers when templates ARE the right choice in Home Assistant, and best practices for writing reliable templates.

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -1,5 +1,6 @@
 > **Prefer a Template Helper over YAML.**
-> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or the UI: Settings → Devices & Services → Helpers → Create Helper → Template.
+> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or via the UI:
+> Settings → Devices & Services → Helpers → Create Helper → Template.
 > Use `template:` YAML only when explicitly requested or when neither programmatic nor UI access is available.
 
 # Template Guidelines


### PR DESCRIPTION
## Summary

- **Step 2** in the decision workflow now guides LLMs to create a **Template Helper** (via UI or config flow API/MCP) before falling back to `template:` YAML when no built-in helper fits
- New **anti-pattern row**: `template:` sensor/binary sensor in YAML → Template Helper (UI or config flow API)
- New **callout** at the top of `references/template-guidelines.md` reinforcing YAML as last resort
- **Description extended** to cover Lovelace dashboard card/sensor selection, with a corresponding symptom bullet
- Version bumped **1.0.0 → 1.1.0**
- Added `evals/evals.json` with 3 regression test cases

## Motivation

LLMs were defaulting to `template:` YAML blocks even when a UI/API-created Template Helper would be simpler, require no file edit, and no config reload. Raised in [ha-mcp#581](https://github.com/homeassistant-ai/ha-mcp/issues/581#issuecomment-4042558094).

## Test plan

- [x] `skills-ref validate` passes
- [x] 20-query trigger eval set: 100% pass rate (train 12/12, test 8/8) after description optimization
- [x] Behavior evals: with-skill correctly routes to Template Helper for attribute extraction and date/time formatting; correctly routes to `min_max` (not Template Helper) for sensor averaging