### PR TITLE
docs(safe-refactoring): add Config-Entry-Groups section

### DIFF
--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -123,14 +123,14 @@ After the registry rename, update group membership via the Options Flow:
 
 1. Initiate the flow:
 
-```bash
+```http
 POST /api/config/config_entries/options/flow
 {"handler": "<group_config_entry_id>"}
 ```
 
 2. Submit the updated member list using the returned `flow_id`:
 
-```bash
+```http
 POST /api/config/config_entries/options/flow/<flow_id>
 {"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": false, "all": false}
 ```

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -107,32 +107,34 @@ When renaming entities that are members of a HA **group** created via the UI (Co
 Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
 
 **Detection (Step 2):**
-List all Config-Entry-based groups and check their current member entity IDs:
+List all Config-Entry-based groups to get their config entry IDs:
 
-```bash
+```
 ha_get_integration(domain="group")
 ```
 
 > **Note:** `ha_get_integration` does not expose `options.entities` in its response (tool
-> limitation). To inspect current members, initiate an Options Flow for each group entry and
-> read the `suggested_value` in the returned `data_schema.entities` field — or read
-> `.storage/core.config_entries` directly and filter by `domain: group`.
+> limitation). The response does include `entry_id` for each group, which is used as the
+> `handler` in the fix step below. To inspect current members, initiate an Options Flow for
+> each group entry and read the `suggested_value` in the returned `data_schema.entities` field.
 
 **Fix (Step 4):**
-After the registry rename, update group membership via the Options Flow:
+After the registry rename, update group membership via the Options Flow.
+Use the `entry_id` from `ha_get_integration(domain="group")` as `<group_config_entry_id>`.
 
-1. Initiate the flow:
+1. Initiate the flow and read the current option values from the response:
 
 ```http
 POST /api/config/config_entries/options/flow
 {"handler": "<group_config_entry_id>"}
 ```
 
-2. Submit the updated member list using the returned `flow_id`:
+2. Submit the updated member list, preserving existing values for `hide_members` and `all`
+   (read from the `suggested_value` fields in the step 1 response):
 
 ```http
 POST /api/config/config_entries/options/flow/<flow_id>
-{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": false, "all": false}
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <existing_value>, "all": <existing_value>}
 ```
 
 **Verify (Step 5):**

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -114,15 +114,19 @@ ha_get_integration(domain="group")
 ```
 
 > **Note:** `ha_get_integration` does not expose `options.entities` in its response (tool
-> limitation). The response does include `entry_id` for each group, which is used as the
-> `handler` in the fix step below. To inspect current members, initiate an Options Flow for
-> each group entry and read the `suggested_value` in the returned `data_schema.entities` field.
+> limitation — returns `options: {}`). The response does include `entry_id` for each group,
+> which is used as the `handler` in the fix step below. To inspect current members, initiate
+> an Options Flow for the group's `entry_id` and read the `suggested_value` in the returned
+> `data_schema.entities` field. Note that HA allows only one active Options Flow per Config
+> Entry at a time — if you open a flow to read current values, complete or abandon it before
+> initiating the fix flow.
 
 **Fix (Step 4):**
 After the registry rename, update group membership via the Options Flow.
 Use the `entry_id` from `ha_get_integration(domain="group")` as `<group_config_entry_id>`.
 
-1. Initiate the flow and read the current option values from the response:
+1. Initiate the flow and read the current option values (`hide_members`, `all`) from
+   the `suggested_value` fields in the response:
 
 ```http
 POST /api/config/config_entries/options/flow
@@ -130,14 +134,18 @@ POST /api/config/config_entries/options/flow
 ```
 
 2. Submit the updated member list, preserving existing values for `hide_members` and `all`
-   (read from the `suggested_value` fields in the step 1 response):
+   (use the `suggested_value` from the step 1 response — do not hardcode `false`):
 
 ```http
 POST /api/config/config_entries/options/flow/<flow_id>
-{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <existing_value>, "all": <existing_value>}
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>, "all": <suggested_value>}
 ```
 
+> **Note:** Cover groups do not have an `all` field — omit it if the step 1 response does
+> not include it in `data_schema`.
+
 **Verify (Step 5):**
-Re-fetch the group config entry (or re-initiate the Options Flow) and confirm that
-`suggested_value` for `entities` contains only the updated entity IDs.
+Re-initiate the Options Flow for the group's `entry_id` and confirm that `suggested_value`
+for `entities` contains only the updated entity IDs. (Direct re-fetch via `ha_get_integration`
+does not show group members — use the Options Flow for verification.)
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -107,45 +107,66 @@ When renaming entities that are members of a HA **group** created via the UI (Co
 Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
 
 **Detection (Step 2):**
-List all Config-Entry-based groups to get their config entry IDs:
+List all Config-Entry-based groups to get their `entry_id` values:
 
+```http
+GET /api/config/config_entries/entry?type=config&domain=group
 ```
-ha_get_integration(domain="group")
-```
 
-> **Note:** `ha_get_integration` does not expose `options.entities` in its response (tool
-> limitation — returns `options: {}`). The response does include `entry_id` for each group,
-> which is used as the `handler` in the fix step below. To inspect current members, initiate
-> an Options Flow for the group's `entry_id` and read the `suggested_value` in the returned
-> `data_schema.entities` field. Note that HA allows only one active Options Flow per Config
-> Entry at a time — if you open a flow to read current values, complete or abandon it before
-> initiating the fix flow.
+> *ha-mcp alternative:* `ha_get_integration(domain="group")` returns the same data, but
+> does not expose `options.entities` (returns `options: {}`). Use the REST endpoint above
+> if you need to confirm current members without initiating a flow.
 
-**Fix (Step 4):**
-After the registry rename, update group membership via the Options Flow.
-Use the `entry_id` from `ha_get_integration(domain="group")` as `<group_config_entry_id>`.
-
-1. Initiate the flow and read the current option values (`hide_members`, `all`) from
-   the `suggested_value` fields in the response:
+To inspect current members of a specific group, initiate an Options Flow and read
+`suggested_value` in the returned `data_schema.entities` field:
 
 ```http
 POST /api/config/config_entries/options/flow
 {"handler": "<group_config_entry_id>"}
 ```
 
-2. Submit the updated member list, preserving existing values for `hide_members` and `all`
-   (use the `suggested_value` from the step 1 response — do not hardcode `false`):
+> **One active flow per Config Entry:** HA allows only one active Options Flow per Config
+> Entry at a time. If you open a detection flow to read current values, abandon or complete
+> it before initiating the fix flow. To abandon:
+>
+> ```http
+> DELETE /api/config/config_entries/options/flow/<flow_id>
+> ```
+
+**Fix (Step 4):**
+After the registry rename, update group membership via the Options Flow.
+
+1. Initiate a new fix flow (the detection flow from above must be abandoned or completed
+   first). Read the current option values from `suggested_value`. Note the `flow_id`:
+
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+2. Submit the updated member list, preserving existing `hide_members` value.
+   Include `all` only if it was present in the step 1 `data_schema` response — only
+   `light`, `switch`, and `binary_sensor` groups support it. For all other group types
+   (fan, lock, media_player, sensor, etc.) omit `all` entirely:
+
+```http
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>}
+```
+
+   If the group type supports `all`, add it explicitly:
 
 ```http
 POST /api/config/config_entries/options/flow/<flow_id>
 {"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>, "all": <suggested_value>}
 ```
 
-> **Note:** Cover groups do not have an `all` field — omit it if the step 1 response does
-> not include it in `data_schema`.
+> **Safe rule:** Always derive field presence from the step 1 `data_schema` response —
+> never hardcode fields. Submitting unknown fields may result in a validation error.
 
 **Verify (Step 5):**
 Re-initiate the Options Flow for the group's `entry_id` and confirm that `suggested_value`
-for `entities` contains only the updated entity IDs. (Direct re-fetch via `ha_get_integration`
-does not show group members — use the Options Flow for verification.)
+for `entities` contains only the updated entity IDs. The REST endpoint
+`GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
+Flow is the only way to read current group members.
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -114,9 +114,9 @@ List all Config-Entry-based groups to get their `entry_id` values:
 GET /api/config/config_entries/entry?type=config&domain=group
 ```
 
-> *ha-mcp alternative:* `ha_get_integration(domain="group")` returns the same data, but
-> does not expose `options.entities` (returns `options: {}`). Use the REST endpoint above
-> if you need to confirm current members without initiating a flow.
+> **Note:** Some HA MCP integrations may not expose all fields from the Config Entries API
+> response — in particular, `options.entities` may be absent. Use the REST endpoint above
+> to confirm current group members directly.
 
 To inspect current members of a specific group, initiate an Options Flow and read
 `suggested_value` in the returned `data_schema.entities` field:

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -27,6 +27,7 @@ Search every component type that references entity IDs. Do not limit searches to
 | Dashboards | `ha_dashboard_find_card(entity_id="...")` or grep `.storage/lovelace*`, `ui-lovelace.yaml` |
 | Scripts | grep `scripts.yaml` |
 | Scenes | grep `scenes.yaml` |
+| Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; `ha_rename_entity` does NOT update these automatically (→ see Config-Entry-Groups section) |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
 
 Record every location found. This list becomes your update checklist for Step 4.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -95,3 +95,47 @@ When converting `device_id` triggers to `entity_id` triggers, or replacing `wait
 
 **Automation callers (Step 2):**
 Search for scripts or other automations that call the automation you are restructuring via `automation.trigger` or `automation.turn_on`. Renaming or splitting an automation changes its entity_id and breaks these callers.
+
+---
+
+## Config-Entry-Groups
+
+When renaming entities that are members of a HA **group** created via the UI (Config-Entry-based group, platform: `group`):
+
+**`ha_rename_entity` does NOT update group members automatically.**
+
+Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
+
+**Detection (Step 2):**
+List all Config-Entry-based groups and check their current member entity IDs:
+
+```bash
+ha_get_integration(domain="group")
+```
+
+> **Note:** `ha_get_integration` does not expose `options.entities` in its response (tool
+> limitation). To inspect current members, initiate an Options Flow for each group entry and
+> read the `suggested_value` in the returned `data_schema.entities` field — or read
+> `.storage/core.config_entries` directly and filter by `domain: group`.
+
+**Fix (Step 4):**
+After the registry rename, update group membership via the Options Flow:
+
+1. Initiate the flow:
+
+```bash
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+2. Submit the updated member list using the returned `flow_id`:
+
+```bash
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": false, "all": false}
+```
+
+**Verify (Step 5):**
+Re-fetch the group config entry (or re-initiate the Options Flow) and confirm that
+`suggested_value` for `entities` contains only the updated entity IDs.
+


### PR DESCRIPTION
## Problem

`ha_rename_entity` renames an entity in the HA registry but does **not** update the `options.entities` list of Config-Entry-based groups (UI-created groups, platform: `group`).

This causes groups to silently reference the old (now non-existent) entity ID after a rename — a gap not covered by the existing Universal Workflow.

Closes #22

## Solution

Adds a new **Config-Entry-Groups** section to `safe-refactoring.md` with:
- Explanation of why `ha_rename_entity` is insufficient for group members
- Detection step with note on tool limitation (`ha_get_integration` does not expose `options.entities`; use Options Flow or storage file)
- Fix: two-step Options Flow API (`POST /api/config/config_entries/options/flow` + submit)
- Verify step

## Source

Discovered and live-tested during a real migration session (Home Assistant 2026.3, 2026-03-15).
Options Flow API verified against a running instance: `POST` initiates flow, second `POST` with `flow_id` submits updated member list.