### PR TITLE
docs(safe-refactoring): add Config-Entry data blind spots and Storage-Mode-Dashboard migration

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -111,7 +111,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring` |
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -111,7 +111,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#config-entry-data--blind-spots-for-ha_rename_entity`, `#storage-mode-dashboards-storagelovelace`, `#helper-replacements`, `#trigger-restructuring` |
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace`, `#helper-replacements`, `#trigger-restructuring` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -34,7 +34,7 @@ Follow this sequence when creating any automation:
 
 ### 0. Gate: modifying existing config?
 
-If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, config-entry data fields, storage dashboard patching, and post-change verification. Complete its workflow before proceeding.
 
 Steps 1-5 below apply to new config or pattern evaluation.
 
@@ -95,8 +95,9 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
 | Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
-| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, and scenes silently | `references/safe-refactoring.md#entity-renames` |
+| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
 | Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | `references/safe-refactoring.md#config-entry-groups` |
+| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames` |
 | `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
 | Searching for or reading HA config files on disk | Use the HA REST/WebSocket API to manage config programmatically | HA is a remote system accessed via APIs; config files are not on the local filesystem | — |
 | Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
@@ -110,7 +111,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring` |
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#config-entry-data--blind-spots-for-ha_rename_entity`, `#storage-mode-dashboards-storagelovelace`, `#helper-replacements`, `#trigger-restructuring` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -34,7 +34,7 @@ Follow this sequence when creating any automation:
 
 ### 0. Gate: modifying existing config?
 
-If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, config-entry data fields, storage dashboard patching, and post-change verification. Complete its workflow before proceeding.
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
 
 Steps 1-5 below apply to new config or pattern evaluation.
 
@@ -111,7 +111,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace`, `#helper-replacements`, `#trigger-restructuring` |
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -173,3 +173,75 @@ for `entities` contains only the updated entity IDs. The REST endpoint
 `GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
 Flow is the only way to read current group members.
 
+
+## Config-Entry Data — Blind Spots for `ha_rename_entity`
+
+**`ha_rename_entity` only updates the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
+
+**Affected integrations and storage fields:**
+
+| Integration | Storage field | Fields containing entity_ids |
+|---|---|---|
+| **Better Thermostat** | `data` | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| Generic Thermostat | `options` | `heater`, `target_sensor` |
+| Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
+| Threshold Helper | `options` | `entity_id` |
+| Min/Max Helper | `options` | `entity_ids` |
+
+**Symptom:** Integration reports "associated entity missing" or behaves incorrectly after restart.
+
+**Timing-critical:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can extend restart time significantly.
+
+**Scan snippet:**
+```bash
+python3 -c "
+import json
+data = json.load(open('/config/.storage/core.config_entries'))
+old_ids = ['old.entity_id']
+for entry in data['data']['entries']:
+    text = json.dumps(entry.get('data', {})) + json.dumps(entry.get('options', {}))
+    hits = [o for o in old_ids if o in text]
+    if hits:
+        print(entry['domain'], entry['title'], hits)
+"
+```
+
+**Fix via Options Flow (REST):**
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<entry_id>"}
+```
+Then submit the returned form with updated entity_ids. See the Config-Entry-Groups section above for the full Options Flow pattern.
+
+---
+
+## Storage-Mode-Dashboards (`.storage/lovelace.*`)
+
+**`ha_rename_entity` does NOT update Lovelace storage dashboards.**
+
+**Recommended fix — no restart required:**
+
+Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save` to write):
+
+```
+1. Read dashboard config:
+   WebSocket: {"type": "lovelace/config", "url_path": "<dashboard_url_path>"}
+   → returns full dashboard config (JSON)
+
+2. Replace entity IDs externally (Python):
+   config_str = json.dumps(config)
+   config_str = config_str.replace('"old.entity_id"', '"new.entity_id"')
+   new_config = json.loads(config_str)
+
+3. Write dashboard config:
+   WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
+   → takes effect immediately, no restart required
+```
+
+HA MCP integrations that expose a dashboard save tool use this WebSocket call internally. The `python_transform` sandbox in some integrations is unsuitable for bulk entity-ID replacement — it blocks `import`, `def`, `isinstance`, and `str.replace()`. Pass the fully replaced config as a plain object instead.
+
+**Fallback — direct file edit (requires restart):**
+Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. Note: files >~40 KB may exceed the `write_file` service limit — compress first with `json.dumps(data, separators=(',', ':'))`.
+
+**List all storage dashboards:**
+WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -174,9 +174,9 @@ for `entities` contains only the updated entity IDs. The REST endpoint
 Flow is the only way to read current group members.
 
 
-## Config-Entry Data — Blind Spots for `ha_rename_entity`
+## Config-Entry Data — Blind Spots for entity registry renames
 
-**`ha_rename_entity` only updates the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
+**Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
 
 **Affected integrations and storage fields:**
 
@@ -217,7 +217,7 @@ Then submit the returned form with updated entity_ids. See the Config-Entry-Grou
 
 ## Storage-Mode-Dashboards (`.storage/lovelace.*`)
 
-**`ha_rename_entity` does NOT update Lovelace storage dashboards.**
+**Entity registry renames do NOT update Lovelace storage dashboards.**
 
 **Recommended fix — no restart required:**
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -116,7 +116,7 @@ List all Config-Entry-based groups to get their `entry_id` values:
 GET /api/config/config_entries/entry?type=config&domain=group
 ```
 
-> **Note:** Some integrations may not expose all fields from the Config Entries API
+> **Note:** Some HA MCP integrations may not expose all fields from the Config Entries API
 > response — in particular, `options.entities` may be absent. Use the REST endpoint above
 > to confirm current group members directly.
 
@@ -173,6 +173,7 @@ for `entities` contains only the updated entity IDs. The REST endpoint
 `GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
 Flow is the only way to read current group members.
 
+
 ## Config-Entry Data — Blind Spots for entity registry renames
 
 **Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
@@ -207,6 +208,7 @@ For integrations that store entity_ids in `data` (Better Thermostat): `data` fie
 
 ---
 
+
 ## Storage-Mode-Dashboards (`.storage/lovelace.*`)
 
 **Entity registry renames do NOT update Lovelace storage dashboards.**
@@ -235,4 +237,3 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
 
 **List all storage dashboards:**
 WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.
-

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -241,7 +241,7 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
 Some HA integrations use this WebSocket call internally for dashboard saves. Scripting sandboxes that restrict Python imports and method calls are unsuitable for bulk entity-ID replacement — pass the fully replaced config as a plain object instead.
 
 **Fallback — direct file edit (requires restart):**
-Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. For large dashboards (>~40 KB) compress the JSON first: `json.dumps(data, separators=(',', ':'))`.
+Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. For large dashboards, compress the JSON first: `json.dumps(data, separators=(',', ':'))`.
 
 **List all storage dashboards:**
 WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -190,28 +190,19 @@ Flow is the only way to read current group members.
 
 **Symptom:** Integration reports "associated entity missing" or behaves incorrectly after restart.
 
-**Timing-critical:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can extend restart time significantly.
+**Timing:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can cause integration setup failures on restart.
 
-**Scan snippet:**
-```bash
-python3 -c "
-import json
-data = json.load(open('/config/.storage/core.config_entries'))
-old_ids = ['old.entity_id']
-for entry in data['data']['entries']:
-    text = json.dumps(entry.get('data', {})) + json.dumps(entry.get('options', {}))
-    hits = [o for o in old_ids if o in text]
-    if hits:
-        print(entry['domain'], entry['title'], hits)
-"
-```
-
-**Fix via Options Flow (REST):**
+**Scan via REST API:**
 ```http
-POST /api/config/config_entries/options/flow
-{"handler": "<entry_id>"}
+GET /api/config/config_entries/entry
 ```
-Then submit the returned form with updated entity_ids. See the Config-Entry-Groups section above for the full Options Flow pattern.
+Iterate the returned entries and check `data` and `options` fields for the old entity ID.
+
+**Fix:**
+
+For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
+
+For integrations that store entity_ids in `data` (Better Thermostat): the Options Flow only updates `options` — `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation. Edit `data` directly in `.storage/core.config_entries` and restart HA.
 
 ---
 
@@ -226,6 +217,7 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
 ```
 1. Read dashboard config:
    WebSocket: {"type": "lovelace/config", "url_path": "<dashboard_url_path>"}
+   Note: the default (Overview) dashboard requires `"url_path": null`; custom dashboards use their string path.
    → returns full dashboard config (JSON)
 
 2. Replace entity IDs externally (Python):
@@ -238,10 +230,7 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
    → takes effect immediately, no restart required
 ```
 
-Some HA integrations use this WebSocket call internally for dashboard saves. Scripting sandboxes that restrict Python imports and method calls are unsuitable for bulk entity-ID replacement — pass the fully replaced config as a plain object instead.
 
-**Fallback — direct file edit (requires restart):**
-Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. For large dashboards, compress the JSON first: `json.dumps(data, separators=(',', ':'))`.
 
 **List all storage dashboards:**
 WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -238,10 +238,10 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
    → takes effect immediately, no restart required
 ```
 
-HA MCP integrations that expose a dashboard save tool use this WebSocket call internally. The `python_transform` sandbox in some integrations is unsuitable for bulk entity-ID replacement — it blocks `import`, `def`, `isinstance`, and `str.replace()`. Pass the fully replaced config as a plain object instead.
+Some HA integrations use this WebSocket call internally for dashboard saves. Scripting sandboxes that restrict Python imports and method calls are unsuitable for bulk entity-ID replacement — pass the fully replaced config as a plain object instead.
 
 **Fallback — direct file edit (requires restart):**
-Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. Note: files >~40 KB may exceed the `write_file` service limit — compress first with `json.dumps(data, separators=(',', ':'))`.
+Edit `.storage/lovelace.<dashboard_id>` directly and restart HA. For large dashboards (>~40 KB) compress the JSON first: `json.dumps(data, separators=(',', ':'))`.
 
 **List all storage dashboards:**
 WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -198,7 +198,7 @@ GET /api/config/config_entries/entry
 ```
 Iterate the returned entries and check `data` and `options` fields for the old entity ID.
 
-> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; see the Fix section below for the applicable fix path (or its absence).
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; the Fix section below documents whether an alternative fix path exists.
 
 **Fix:**
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -173,7 +173,6 @@ for `entities` contains only the updated entity IDs. The REST endpoint
 `GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
 Flow is the only way to read current group members.
 
-
 ## Config-Entry Data — Blind Spots for entity registry renames
 
 **Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
@@ -236,3 +235,4 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
 
 **List all storage dashboards:**
 WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.
+

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -28,6 +28,7 @@ Search every component type that references entity IDs. Do not limit searches to
 | Scripts | grep `scripts.yaml` |
 | Scenes | grep `scenes.yaml` |
 | Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; entity registry renames do NOT update these automatically (→ see Config-Entry-Groups section) |
+| Config-Entry integrations (Better Thermostat, Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper) | `GET /api/config/config_entries/entry` — scan `data` and `options` fields for the old entity ID; entity registry renames do NOT update these fields automatically (→ see Config-Entry-Data section) |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
 
 Record every location found. This list becomes your update checklist for Step 4.
@@ -223,13 +224,19 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
    Note: the default (Overview) dashboard requires `"url_path": null`; custom dashboards use their string path.
    → returns full dashboard config (JSON)
 
-2. Replace entity IDs externally (Python):
-   config_str = json.dumps(config)
-   config_str = config_str.replace('"old.entity_id"', '"new.entity_id"')
-   new_config = json.loads(config_str)
+2. Replace entity IDs (Python — JSON-aware, boundary-safe):
+   def _replace_ids(obj, old_id, new_id):
+       if isinstance(obj, str): return new_id if obj == old_id else obj
+       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id) for i in obj]
+       if isinstance(obj, dict): return {(new_id if k == old_id else k): _replace_ids(v, old_id, new_id) for k, v in obj.items()}
+       return obj
+   new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
+   # Note: string replace on json.dumps() is not boundary-safe — it matches entity IDs
+   # that appear as JSON keys or as substrings of other strings in the serialized output.
 
 3. Write dashboard config:
    WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
+   Note: use `"url_path": null` for the default (Overview) dashboard; use the string path for custom dashboards.
    → takes effect immediately, no restart required
 ```
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -116,7 +116,7 @@ List all Config-Entry-based groups to get their `entry_id` values:
 GET /api/config/config_entries/entry?type=config&domain=group
 ```
 
-> **Note:** Some HA MCP integrations may not expose all fields from the Config Entries API
+> **Note:** Some integrations may not expose all fields from the Config Entries API
 > response — in particular, `options.entities` may be absent. Use the REST endpoint above
 > to confirm current group members directly.
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -204,7 +204,7 @@ Iterate the returned entries and check `data` and `options` fields for the old e
 
 For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
 
-For integrations that store entity_ids in `data` (Better Thermostat): the Options Flow only updates `options` — `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation. Edit `data` directly in `.storage/core.config_entries` and restart HA.
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -182,7 +182,7 @@ Flow is the only way to read current group members.
 
 | Integration | Storage field | Fields containing entity_ids |
 |---|---|---|
-| **Better Thermostat** | `data` (not accessible via REST — see note above) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| **Better Thermostat** | `data` (not accessible via REST — see note below) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
 | Generic Thermostat | `options` | `heater`, `target_sensor` |
 | Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
 | Threshold Helper | `options` | `entity_id` |
@@ -198,7 +198,7 @@ GET /api/config/config_entries/entry
 ```
 Iterate the returned entries and check `data` and `options` fields for the old entity ID.
 
-> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; use the Options Flow (see Fix section below) to inspect and update the configuration instead.
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; see the Fix section below for the applicable fix path (or its absence).
 
 **Fix:**
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -182,7 +182,7 @@ Flow is the only way to read current group members.
 
 | Integration | Storage field | Fields containing entity_ids |
 |---|---|---|
-| **Better Thermostat** | `data` | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| **Better Thermostat** | `data` (not accessible via REST — see note above) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
 | Generic Thermostat | `options` | `heater`, `target_sensor` |
 | Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
 | Threshold Helper | `options` | `entity_id` |
@@ -197,6 +197,8 @@ Flow is the only way to read current group members.
 GET /api/config/config_entries/entry
 ```
 Iterate the returned entries and check `data` and `options` fields for the old entity ID.
+
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; use the Options Flow (see Fix section below) to inspect and update the configuration instead.
 
 **Fix:**
 

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -223,10 +223,14 @@ template:
 ### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
 
 **If long-term statistics are needed, set `state_class`.** Without it, HA writes no
-long-term statistics — the sensor will not appear in `statistics_meta` and will be invisible
-to the Energy Dashboard and History graphs. `state_class` is optional for diagnostic or
-one-shot sensors where statistics are not required.
+long-term statistics — the sensor will not appear in `statistics_meta` or in History graphs.
+`state_class` is optional for diagnostic or one-shot sensors where statistics are not required.
 (Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
+
+> **Energy Dashboard note:** `state_class` alone is not sufficient for Energy Dashboard
+> visibility. The sensor also needs `device_class: energy` (or `power`, `gas`, etc.) to
+> appear as a selectable source. A sensor with `state_class` but no matching `device_class`
+> will have long-term statistics but will not appear in the Energy Dashboard configuration.
 
 Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
 
@@ -274,11 +278,13 @@ template:
 uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
 and no warnings — but all official HA docs now use plural. Write new templates in plural form.
 
-**Consolidate same-type entities in one block.** All `sensor` or `binary_sensor` entries of
-the same type belong in a single block, not in separate blocks per entity:
+**Consolidate state-based entities of the same type in one block.** Multiple state-based
+`sensor` or `binary_sensor` entries without individual triggers belong in a single block —
+not in separate blocks per entity. Trigger-based blocks (with their own `triggers:` section)
+must be separate regardless of entity type, since each block defines its own trigger context:
 
 ```yaml
-# CORRECT — one block, multiple entries:
+# CORRECT — state-based sensors: one block, multiple entries:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -288,25 +294,31 @@ template:
         unique_id: motion_room_b
         state: "{{ ... }}"
 
-# AVOID — separate block per entity:
+# AVOID — state-based sensors split across separate blocks:
 template:
   - binary_sensor:
       - name: "Motion Room A"
+        unique_id: motion_room_a_avoid
+        state: "{{ ... }}"
   - binary_sensor:
       - name: "Motion Room B"
+        unique_id: motion_room_b_avoid
+        state: "{{ ... }}"
 ```
 
-**Use 4-space indentation for list items under block keys.** Official HA template docs consistently
-use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid but creates
-visual ambiguity:
+> **Trigger-based blocks are always separate** — a block with `triggers:` defines its own
+> update context and cannot share a block with entries of a different trigger configuration.
+> Only consolidate entries that share the same trigger context (or are all state-based).
+
+**Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
 
 ```yaml
-# CORRECT — 4-space indent, matches official docs:
+# Standard — 2-space indent per level (HA Style Guide, matches official docs):
 - binary_sensor:
     - name: "My Sensor"
       state: "{{ ... }}"
 
-# VALID but harder to read — avoid:
+# Non-standard — compact notation (valid YAML, but absent from official HA docs):
 - binary_sensor:
   - name: "My Sensor"
 ```
@@ -530,7 +542,7 @@ sensor:
 ```yaml
 # EFFICIENT - Only runs when specified triggers fire
 template:
-  - trigger:
+  - triggers:
       - trigger: time_pattern
         minutes: "/5"  # Every 5 minutes
     sensor:

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -223,14 +223,10 @@ template:
 ### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
 
 **If long-term statistics are needed, set `state_class`.** Without it, HA writes no
-long-term statistics — the sensor will not appear in `statistics_meta` or in History graphs.
-`state_class` is optional for diagnostic or one-shot sensors where statistics are not required.
+long-term statistics — the sensor will not appear in `statistics_meta` and will be invisible
+to the Energy Dashboard and History graphs. `state_class` is optional for diagnostic or
+one-shot sensors where statistics are not required.
 (Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
-
-> **Energy Dashboard note:** `state_class` alone is not sufficient for Energy Dashboard
-> visibility. The sensor also needs `device_class: energy` (or `power`, `gas`, etc.) to
-> appear as a selectable source. A sensor with `state_class` but no matching `device_class`
-> will have long-term statistics but will not appear in the Energy Dashboard configuration.
 
 Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
 
@@ -278,13 +274,11 @@ template:
 uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
 and no warnings — but all official HA docs now use plural. Write new templates in plural form.
 
-**Consolidate state-based entities of the same type in one block.** Multiple state-based
-`sensor` or `binary_sensor` entries without individual triggers belong in a single block —
-not in separate blocks per entity. Trigger-based blocks (with their own `triggers:` section)
-must be separate regardless of entity type, since each block defines its own trigger context:
+**Consolidate same-type entities in one block.** All `sensor` or `binary_sensor` entries of
+the same type belong in a single block, not in separate blocks per entity:
 
 ```yaml
-# CORRECT — state-based sensors: one block, multiple entries:
+# CORRECT — one block, multiple entries:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -294,31 +288,25 @@ template:
         unique_id: motion_room_b
         state: "{{ ... }}"
 
-# AVOID — state-based sensors split across separate blocks:
+# AVOID — separate block per entity:
 template:
   - binary_sensor:
       - name: "Motion Room A"
-        unique_id: motion_room_a_avoid
-        state: "{{ ... }}"
   - binary_sensor:
       - name: "Motion Room B"
-        unique_id: motion_room_b_avoid
-        state: "{{ ... }}"
 ```
 
-> **Trigger-based blocks are always separate** — a block with `triggers:` defines its own
-> update context and cannot share a block with entries of a different trigger configuration.
-> Only consolidate entries that share the same trigger context (or are all state-based).
-
-**Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
+**Use 4-space indentation for list items under block keys.** Official HA template docs consistently
+use 4-space indent under `sensor:` / `binary_sensor:`. Two-space is YAML-valid but creates
+visual ambiguity:
 
 ```yaml
-# Standard — 2-space indent per level (HA Style Guide, matches official docs):
+# CORRECT — 4-space indent, matches official docs:
 - binary_sensor:
     - name: "My Sensor"
       state: "{{ ... }}"
 
-# Non-standard — compact notation (valid YAML, but absent from official HA docs):
+# VALID but harder to read — avoid:
 - binary_sensor:
   - name: "My Sensor"
 ```
@@ -542,7 +530,7 @@ sensor:
 ```yaml
 # EFFICIENT - Only runs when specified triggers fire
 template:
-  - triggers:
+  - trigger:
       - trigger: time_pattern
         minutes: "/5"  # Every 5 minutes
     sensor:


### PR DESCRIPTION
## Summary

Extends `references/safe-refactoring.md` and `SKILL.md` with two new sections covering blind spots that `ha_rename_entity` does not handle automatically.

## Changes

**`references/safe-refactoring.md`** — two new sections:
- **Config-Entry Data — Blind Spots for `ha_rename_entity`**: Integrations that store entity_ids in Config Entry `data`/`options` fields (Better Thermostat, Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper) are not updated by `ha_rename_entity`. Includes affected integrations table, scan snippet, and Options Flow fix pattern.
- **Storage-Mode-Dashboards**: Lovelace storage dashboards are not updated by `ha_rename_entity`. Documents the correct WebSocket API workflow (no HA restart required) and a direct file fallback.

**`SKILL.md`**:
- Extended gate text to mention config-entry data fields and storage dashboard patching
- Two new anti-pattern rows in the quick-reference table
- Expanded `safe-refactoring.md` anchor references

**`references/template-guidelines.md`**: upstream-aligned (content from PR #18 already merged).

## Verification

Live-verified on HA 2026.3.2 (21.03.2026):
- `lovelace/config/save` WebSocket command takes effect immediately — no restart required
- `python_transform` sandbox blocks `import`/`def`/`isinstance`/`str.replace`
- Config-Entry `data`/`options` fields verified against `core.config_entries`

## Note on entity-naming.md

The originally proposed `references/entity-naming.md` has been removed. Naming conventions are installation-specific and not suitable for a shared upstream skill per CONTRIBUTING.md. That content belongs in per-installation `CLAUDE.md` or a personal skill (see also issue #23 — that issue remains open as the naming convention gap is not addressed by this PR).