### PR TITLE
fix(safe-refactoring): add views[n].badges to dashboard reference locations

### DIFF
--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -72,6 +72,7 @@ Dashboard cards reference entities in multiple places. Search all of these:
 - `tap_action` and `hold_action` targets
 - Conditional card conditions
 - Template card Jinja2 blocks
+- `views[n].badges` — badge rows per view; badges are siblings of the cards array, not children, so any card-focused search will miss them — always search the full dashboard config
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `views[n].badges` to the dashboard reference locations checklist in `references/safe-refactoring.md`
- Explains *why* badges are missed: they are siblings of the `cards` array at the view level, not children, so any card-focused search skips them entirely
- Guidance is tool-agnostic — describes the HA data structure rather than any specific MCP tool behavior

Closes #28