### PR TITLE
fix(safe-refactoring): replace tool-specific references with HA concepts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ description: >
 
 Constraints from CONTRIBUTING.md:
 - Max **500 lines** per SKILL.md
+- `metadata.version` must be `0` on new skills (CI assigns real version on merge; do not edit manually)
 - Reference files must be **one level deep** only (e.g. `references/example.yaml`)
 - Use **forward slashes** in all file paths
 - Optional subdirectories: `references/` (additional docs), `scripts/` (utility scripts), `assets/` (static resources)
@@ -36,6 +37,7 @@ Constraints from CONTRIBUTING.md:
 - **Conciseness** — provide patterns and quick-reference tables, not tutorials
 - **Consistent terminology** — one term per concept throughout a skill
 - **Symptom-based triggering** — the `description` frontmatter should describe observable agent behaviors that signal the skill is needed
+- **No tool names** — reference HA REST APIs and concepts, never specific MCP tool names (e.g. `ha_rename_entity`); tool names vary by agent setup
 
 ## Validation
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -27,7 +27,7 @@ Search every component type that references entity IDs. Do not limit searches to
 | Dashboards | Search dashboard configs for the entity ID via the HA API or grep `.storage/lovelace*`, `ui-lovelace.yaml` |
 | Scripts | grep `scripts.yaml` |
 | Scenes | grep `scenes.yaml` |
-| Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; `ha_rename_entity` does NOT update these automatically (→ see Config-Entry-Groups section) |
+| Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; entity registry renames do NOT update these automatically (→ see Config-Entry-Groups section) |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
 
 Record every location found. This list becomes your update checklist for Step 4.
@@ -104,7 +104,7 @@ Search for scripts or other automations that call the automation you are restruc
 
 When renaming entities that are members of a HA **group** created via the UI (Config-Entry-based group, platform: `group`):
 
-**`ha_rename_entity` does NOT update group members automatically.**
+**Entity registry renames do NOT update group members automatically.**
 
 Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
 


### PR DESCRIPTION
## Summary

- Replaces two `ha_rename_entity` mentions with "entity registry renames" in `references/safe-refactoring.md`
- Adds "no tool names" principle and `metadata.version` requirement to `CLAUDE.md`

Describes the underlying HA mechanism rather than a specific MCP tool name, per the contributing guidelines: *"Don't couple skills to specific tool names. Tool names change and not all agents have the same toolset; the underlying HA APIs and concepts are stable."*