### PR TITLE
docs: add storage-schemas.md reference for input_number/.storage keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,4 +50,5 @@ The template covers five sections: context, timeline, root cause, impact, and en
 2. Create a folder under `skills/` with your skill name.
 3. Write a `SKILL.md` following the format above.
 4. Test your skill with real scenarios.
-5. Submit a pull request describing what your skill teaches and what problems it solves.
+5. If you added or removed reference files, update the **Skill Contents** table in `README.md`.
+6. Submit a pull request describing what your skill teaches and what problems it solves.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository provides an Agent Skill for Home Assistant, following the open [
 
 ## Included Skill
 
-**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, device control best practices, and safe refactoring.
+**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, device control best practices, dashboard configuration, and safe refactoring.
 
 ## Installation
 
@@ -34,7 +34,7 @@ Run each command separately inside Claude Code:
 /plugin install home-assistant-skills@homeassistant-ai-skills
 ```
 
-Restart Claude Code after installation for the skill to take effect.
+Run `/reload-plugins` or restart Claude Code for the skill to take effect.
 
 ### Claude Desktop / claude.ai
 
@@ -54,6 +54,9 @@ The `home-assistant-best-practices` skill includes:
 | `references/helper-selection.md` | Built-in helpers vs template sensors (with decision matrix) |
 | `references/template-guidelines.md` | When templates are the right choice |
 | `references/device-control.md` | Service calls, entity_id vs device_id, Zigbee buttons |
+| `references/dashboard-guide.md` | Dashboard layout, view types, sections, custom cards, CSS styling |
+| `references/dashboard-cards.md` | Card type lookup and card-specific documentation |
+| `references/domain-docs.md` | Integration and domain documentation for service calls, entity attributes |
 | `references/examples.yaml` | Compound examples combining multiple best practices |
 
 ## Contributing

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -95,8 +95,9 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
 | Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
-| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, and scenes silently | `references/safe-refactoring.md#entity-renames` |
+| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
 | Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | `references/safe-refactoring.md#config-entry-groups` |
+| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames` |
 | `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
 | Searching for or reading HA config files on disk | Use the HA REST/WebSocket API to manage config programmatically | HA is a remote system accessed via APIs; config files are not on the local filesystem | — |
 | Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
@@ -110,7 +111,7 @@ Read these when you need detailed information:
 
 | File | When to read | Key sections |
 |------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring` |
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
 | `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -119,4 +119,4 @@ Read these when you need detailed information:
 | `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |
 | `references/domain-docs.md` | Looking up integration or domain documentation for service calls, entity attributes, or configuration | — |
 | `references/examples.yaml` | Need compound examples combining multiple best practices | — |
-| `references/storage-schemas.md` | Writing directly to `.storage/` files (input_number, input_boolean, etc.) — min/max schema, entity_registry cleanup | `#input-number`, `#entity-registry` |
+| `references/storage-schemas.md` | Writing directly to `.storage/` files for input_number, input_boolean — min/max schema, entity_registry cleanup | `#input-number`, `#entity-registry` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -119,3 +119,4 @@ Read these when you need detailed information:
 | `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |
 | `references/domain-docs.md` | Looking up integration or domain documentation for service calls, entity attributes, or configuration | — |
 | `references/examples.yaml` | Need compound examples combining multiple best practices | — |
+| `references/storage-schemas.md` | Writing directly to `.storage/` files (input_number, input_boolean, etc.) — min/max schema, entity_registry cleanup | `#input-number`, `#entity-registry` |

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -28,6 +28,7 @@ Search every component type that references entity IDs. Do not limit searches to
 | Scripts | grep `scripts.yaml` |
 | Scenes | grep `scenes.yaml` |
 | Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; entity registry renames do NOT update these automatically (→ see Config-Entry-Groups section) |
+| Config-Entry integrations (Better Thermostat, Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper) | `GET /api/config/config_entries/entry` — scan `data` and `options` fields for the old entity ID; entity registry renames do NOT update these fields automatically (→ see Config-Entry-Data section) |
 | Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
 
 Record every location found. This list becomes your update checklist for Step 4.
@@ -173,3 +174,73 @@ for `entities` contains only the updated entity IDs. The REST endpoint
 `GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
 Flow is the only way to read current group members.
 
+
+## Config-Entry Data — Blind Spots for entity registry renames
+
+**Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
+
+**Affected integrations and storage fields:**
+
+| Integration | Storage field | Fields containing entity_ids |
+|---|---|---|
+| **Better Thermostat** | `data` (not accessible via REST — see note below) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| Generic Thermostat | `options` | `heater`, `target_sensor` |
+| Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
+| Threshold Helper | `options` | `entity_id` |
+| Min/Max Helper | `options` | `entity_ids` |
+
+**Symptom:** Integration reports "associated entity missing" or behaves incorrectly after restart.
+
+**Timing:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can cause integration setup failures on restart.
+
+**Scan via REST API:**
+```http
+GET /api/config/config_entries/entry
+```
+Iterate the returned entries and check `data` and `options` fields for the old entity ID.
+
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; the Fix section below documents whether an alternative fix path exists.
+
+**Fix:**
+
+For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
+
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename.
+
+---
+
+
+## Storage-Mode-Dashboards (`.storage/lovelace.*`)
+
+**Entity registry renames do NOT update Lovelace storage dashboards.**
+
+**Recommended fix — no restart required:**
+
+Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save` to write):
+
+```
+1. Read dashboard config:
+   WebSocket: {"type": "lovelace/config", "url_path": "<dashboard_url_path>"}
+   Note: the default (Overview) dashboard requires `"url_path": null`; custom dashboards use their string path.
+   → returns full dashboard config (JSON)
+
+2. Replace entity IDs (Python — JSON-aware, boundary-safe):
+   def _replace_ids(obj, old_id, new_id):
+       if isinstance(obj, str): return new_id if obj == old_id else obj
+       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id) for i in obj]
+       if isinstance(obj, dict): return {(new_id if k == old_id else k): _replace_ids(v, old_id, new_id) for k, v in obj.items()}
+       return obj
+   new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
+   # Note: string replace on json.dumps() is not boundary-safe — it matches entity IDs
+   # that appear as JSON keys or as substrings of other strings in the serialized output.
+
+3. Write dashboard config:
+   WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
+   Note: use `"url_path": null` for the default (Overview) dashboard; use the string path for custom dashboards.
+   → takes effect immediately, no restart required
+```
+
+
+
+**List all storage dashboards:**
+WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/skills/home-assistant-best-practices/references/storage-schemas.md
+++ b/skills/home-assistant-best-practices/references/storage-schemas.md
@@ -35,12 +35,7 @@ that agents may need to read or write directly via the HA file API or SSH.
 }
 ```
 
-**Key notes:**
-- Keys are `min` / `max` — **not** `minimum` / `maximum`
-- Same key names as in `configuration.yaml` YAML config
-- `initial`, `unit_of_measurement`, `icon` are optional
-- `mode`: `"box"` or `"slider"`
-- `id` must match the `unique_id` in `core.entity_registry`
+**Key notes:** Keys are `min` / `max` (not `minimum` / `maximum`), same as in `configuration.yaml`. `initial`, `unit_of_measurement`, and `icon` are optional. `mode`: `"box"` or `"slider"`. `id` must match the `unique_id` in `core.entity_registry`.
 
 **After writing:** call `input_number/reload` or restart HA.
 
@@ -67,9 +62,7 @@ that agents may need to read or write directly via the HA file API or SSH.
 }
 ```
 
-**Key notes:**
-- No `initial` field — state is not persisted here
-- `icon` is optional
+**Key notes:** No `initial` field — state is not persisted here. `icon` is optional.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/storage-schemas.md
+++ b/skills/home-assistant-best-practices/references/storage-schemas.md
@@ -1,0 +1,99 @@
+# Storage Schemas Reference
+
+This document covers the JSON schema for Home Assistant `.storage/` files
+that agents may need to read or write directly via `write_file` or SSH.
+
+> ⚠️ Always read the existing `.storage/` file before writing — use it as the
+> canonical schema reference. Never reconstruct schemas from memory.
+
+---
+
+## input_number
+
+**File:** `/config/.storage/input_number`
+
+```json
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "input_number",
+  "data": {
+    "items": [
+      {
+        "id": "my_helper",
+        "name": "Display Name",
+        "min": 0.0,
+        "max": 100.0,
+        "step": 0.5,
+        "initial": 21.0,
+        "mode": "box",
+        "unit_of_measurement": "°C",
+        "icon": "mdi:thermometer"
+      }
+    ]
+  }
+}
+```
+
+**Key notes:**
+- Keys are `min` / `max` — **not** `minimum` / `maximum`
+- Same key names as in `configuration.yaml` YAML config
+- `initial`, `unit_of_measurement`, `icon` are optional
+- `mode`: `"box"` or `"slider"`
+- `id` must match the `unique_id` in `core.entity_registry`
+
+**After writing:** call `input_number/reload` or restart HA.
+
+---
+
+## input_boolean
+
+**File:** `/config/.storage/input_boolean`
+
+```json
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "input_boolean",
+  "data": {
+    "items": [
+      {
+        "id": "my_flag",
+        "name": "Display Name",
+        "icon": "mdi:toggle-switch"
+      }
+    ]
+  }
+}
+```
+
+**Key notes:**
+- No `initial` field — state is not persisted here
+- `icon` is optional
+
+---
+
+## entity_registry (cleanup)
+
+**File:** `/config/.storage/core.entity_registry`
+
+Structure: `{ "data": { "entities": [ {...}, ... ] } }`
+
+To remove stale entries (e.g. after a helper was deleted via UI but
+its zombie persists):
+
+```python
+import json, shutil
+shutil.copy('/config/.storage/core.entity_registry',
+            '/config/.storage/core.entity_registry.bak')
+with open('/config/.storage/core.entity_registry', 'r') as f:
+    reg = json.load(f)
+reg['data']['entities'] = [
+    e for e in reg['data']['entities']
+    if e.get('unique_id') != 'the_id_to_remove'
+]
+with open('/config/.storage/core.entity_registry', 'w') as f:
+    json.dump(reg, f)
+```
+
+**After writing:** restart HA (reload is not sufficient for registry changes).

--- a/skills/home-assistant-best-practices/references/storage-schemas.md
+++ b/skills/home-assistant-best-practices/references/storage-schemas.md
@@ -1,7 +1,7 @@
 # Storage Schemas Reference
 
 This document covers the JSON schema for Home Assistant `.storage/` files
-that agents may need to read or write directly via `write_file` or SSH.
+that agents may need to read or write directly via the HA file API or SSH.
 
 > ⚠️ Always read the existing `.storage/` file before writing — use it as the
 > canonical schema reference. Never reconstruct schemas from memory.
@@ -82,7 +82,7 @@ Structure: `{ "data": { "entities": [ {...}, ... ] } }`
 To remove stale entries (e.g. after a helper was deleted via UI but
 its zombie persists):
 
-Run via SSH terminal (`core.entity_registry` is ~2–3 MB — too large for `write_file`):
+Run via SSH terminal (`core.entity_registry` is ~2–3 MB — too large for the HA file API):
 
 ```python
 import json, shutil

--- a/skills/home-assistant-best-practices/references/storage-schemas.md
+++ b/skills/home-assistant-best-practices/references/storage-schemas.md
@@ -35,7 +35,7 @@ that agents may need to read or write directly via the HA file API or SSH.
 }
 ```
 
-**Key notes:** Keys are `min` / `max` (not `minimum` / `maximum`), same as in `configuration.yaml`. `initial`, `unit_of_measurement`, and `icon` are optional. `mode`: `"box"` or `"slider"`. `id` must match the `unique_id` in `core.entity_registry`.
+**Key notes:** Keys are `min` / `max` (not `minimum` / `maximum`), same as in `configuration.yaml`. `initial`, `unit_of_measurement`, and `icon` are optional. `mode`: `"box"` or `"slider"`. The `id` value (e.g. `my_helper`) forms the `unique_id` in `core.entity_registry` as `input_number.<id>` (e.g. `input_number.my_helper`).
 
 **After writing:** call `input_number/reload` or restart HA.
 
@@ -62,7 +62,7 @@ that agents may need to read or write directly via the HA file API or SSH.
 }
 ```
 
-**Key notes:** No `initial` field — state is not persisted here. `icon` is optional.
+**Key notes:** No `initial` field — the on/off state is persisted by HA separately (in `core.restore_state`), not in this storage file. `icon` is optional.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/storage-schemas.md
+++ b/skills/home-assistant-best-practices/references/storage-schemas.md
@@ -82,6 +82,8 @@ Structure: `{ "data": { "entities": [ {...}, ... ] } }`
 To remove stale entries (e.g. after a helper was deleted via UI but
 its zombie persists):
 
+Run via SSH terminal (`core.entity_registry` is ~2–3 MB — too large for `write_file`):
+
 ```python
 import json, shutil
 shutil.copy('/config/.storage/core.entity_registry',
@@ -93,7 +95,7 @@ reg['data']['entities'] = [
     if e.get('unique_id') != 'the_id_to_remove'
 ]
 with open('/config/.storage/core.entity_registry', 'w') as f:
-    json.dump(reg, f)
+    json.dump(reg, f, ensure_ascii=False)
 ```
 
 **After writing:** restart HA (reload is not sufficient for registry changes).


### PR DESCRIPTION
Adds one row to the reference table pointing to a new `references/storage-schemas.md`.

Background: `.storage/input_number` uses `min`/`max` keys (not `minimum`/`maximum` as in YAML config). This confusion caused a `KeyError: 'min'` at HA startup when writing the storage file directly.

The new reference entry signals that agents should consult storage-schemas when writing `.storage/` files directly rather than guessing from memory.