### PR TITLE
docs(automation-patterns): add enabled:false anti-pattern and Disabling Automations section

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -101,6 +101,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Searching for or reading HA config files on disk | Use the HA REST/WebSocket API to manage config programmatically | HA is a remote system accessed via APIs; config files are not on the local filesystem | — |
 | Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
 | Telling user to edit `configuration.yaml` for integrations | Direct user to Settings > Devices & Services in the HA UI | Most integrations are UI-configured; YAML integration config is rare and integration-specific | — |
+| `enabled: false` in `automations.yaml` for UI automations | `automation.turn_off` service call or UI disable (Settings > Automations > kebab menu) | YAML flag conflicts with entity registry entry — creates Repair issue not detected by `check_config` | `references/automation-patterns.md#disabling-automations` |
 
 ---
 

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -506,6 +506,41 @@ automation:
 
 ---
 
+## Disabling Automations
+
+Use `automation.turn_off` or the UI to disable an automation — do not use `enabled: false` in `automations.yaml`.
+
+Home Assistant stores UI-created automations in both the YAML file and the entity registry. Setting `enabled: false` in the YAML file conflicts with the registry entry and creates a Repair issue. The conflict is not detected by `check_config`.
+
+```yaml
+# ❌ WRONG - causes Repair issue for UI automations
+automation:
+  - id: my_automation
+    alias: "My Automation"
+    enabled: false   # conflicts with entity registry entry
+    trigger: ...
+```
+
+```yaml
+# ✅ RIGHT - disable via service call (temporary, survives reload)
+action: automation.turn_off
+target:
+  entity_id: automation.my_automation
+data:
+  stop_actions: false  # optional: let current run finish
+
+# ✅ ALSO RIGHT - re-enable with:
+action: automation.turn_on
+target:
+  entity_id: automation.my_automation
+```
+
+For permanent disabling, use the HA UI: **Settings > Automations > select automation > kebab menu > Disable**. This writes to the entity registry directly.
+
+**When `enabled: false` in YAML is acceptable:** Only for automations that have never been loaded by HA as a UI automation and have no entity registry entry. In practice, any automation that has appeared in the UI has a registry entry; use `automation.turn_off` or the UI instead.
+
+---
+
 ## if/then vs choose
 
 ### if/then/else


### PR DESCRIPTION
## Problem

Setting `enabled: false` in `automations.yaml` for UI-managed automations causes a Repair issue in Home Assistant. The conflict between the YAML flag and the entity registry entry is not detected by `check_config`, making it a silent failure mode.

Verified on HA 2026.3.3 (LB instance, 25.03.2026).

## Changes

- **`references/automation-patterns.md`**: New `## Disabling Automations` section with WRONG/RIGHT examples. Correct approach: `automation.turn_off` service call (temporary) or UI disable via Settings > Automations > kebab menu (permanent via entity registry). Includes caveat for YAML-only automations without registry entries.
- **`SKILL.md`**: New anti-pattern row: `enabled: false` in `automations.yaml` for UI automations → `automation.turn_off` service call or UI disable.

## Verification

- `automation.turn_off` with `stop_actions` field confirmed via `GET /api/services` on live HA instance
- No REST endpoint exists for entity registry writes in HA 2026.3 — UI path documented instead
- No MCP tool names, no instance-specific values, no German text