### PR TITLE
docs(automation-patterns): add disabling automations section

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -93,6 +93,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see `references/safe-refactoring.md#trigger-restructuring` for semantic differences) | `references/automation-patterns.md#wait-actions` |
 | `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | `references/device-control.md#entity-id-vs-device-id` |
 | `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
+| `enabled: false` as a top-level key in `automations.yaml` | `automation.turn_off` (temporary) or entity registry disable (permanent) | Not a valid top-level key — rejected during schema validation; automation loads as `unavailable` | `references/automation-patterns.md#disabling-automations` |
 | Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
 | Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
 | Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
@@ -112,7 +113,7 @@ Read these when you need detailed information:
 | File | When to read | Key sections |
 |------|--------------|--------------|
 | `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
-| `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids` |
+| `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes; disabling automations | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids`, `#disabling-automations` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |
 | `references/device-control.md` | Writing service calls, Zigbee button automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#zigbee-buttonremote-patterns`, `#domain-specific-patterns` |

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -609,7 +609,7 @@ Home Assistant provides two distinct ways to disable an automation, with differe
 
 ### Method 1: Turn Off (Temporary, State Machine)
 
-`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be triggered manually via `automation.trigger`.
+`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` service.
 
 ```yaml
 action: automation.turn_off
@@ -641,12 +641,12 @@ Disabling an automation via *Settings → Automations → open automation → �
 | Requires `id:` field? | Yes — the `id:` field in `automations.yaml` becomes the automation's `unique_id`, which is required for an entity registry entry |
 | Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update` with `{"disabled_by": null}`) |
 
-**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *⋮ → Settings* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`.
+**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`, or registry-disabled but with a stored `on` state.
 
 ### AVOID: `enabled: false` in automations.yaml
 
 ```yaml
-# AVOID — causes FAILED_SCHEMA on load
+# AVOID — enabled: is not a valid top-level key
 - alias: My Automation
   enabled: false       # not a valid top-level key
   triggers: ...

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -623,7 +623,7 @@ data:
 | --- | --- |
 | `stop_actions` | Optional. Stops currently active action runs. **Defaults to `true`.** |
 | Survives reload? | Yes — state is stored in `core.restore_state` |
-| Survives restart? | Only if the automation has an `id:` field — `core.restore_state` matches by `entity_id`, which is derived from `alias:` without `id:` and is unstable if automations are reordered |
+| Survives restart? | Only if the automation has an `id:` field — `core.restore_state` matches by `entity_id`, which is derived from `alias:` without `id:` and is unstable if automations are added, removed, or have conflicting aliases |
 | Entity in state machine? | Yes — state is `off` |
 | Re-enable via | `automation.turn_on` |
 
@@ -639,7 +639,7 @@ Disabling an automation via *Settings → Automations → open automation → �
 | Survives restart? | Yes |
 | Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
 | Requires `id:` field? | Yes — the `id:` field in `automations.yaml` becomes the automation's `unique_id`, which is required for an entity registry entry |
-| Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update`) |
+| Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update` with `{"disabled_by": null}`) |
 
 **Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *⋮ → Settings* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`.
 

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -609,7 +609,7 @@ Home Assistant provides two distinct ways to disable an automation, with differe
 
 ### Method 1: Turn Off (Temporary, State Machine)
 
-`automation.turn_off` disables the automation's triggers. The entity remains in the state machine with state `off` and can be re-triggered manually.
+`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be triggered manually via `automation.trigger`.
 
 ```yaml
 action: automation.turn_off
@@ -623,25 +623,25 @@ data:
 | --- | --- |
 | `stop_actions` | Optional. Stops currently active action runs. **Defaults to `true`.** |
 | Survives reload? | Yes — state is stored in `core.restore_state` |
-| Survives restart? | Only if the automation has an `id:` field (stored in `core.restore_state`) |
+| Survives restart? | Only if the automation has an `id:` field — `core.restore_state` matches by `entity_id`, which is derived from `alias:` without `id:` and is unstable if automations are reordered |
 | Entity in state machine? | Yes — state is `off` |
 | Re-enable via | `automation.turn_on` |
 
-**`initial_state` override:** If the automation YAML contains `initial_state: true`, it will override the stored `off` state after a restart.
+**`initial_state` override:** If the automation YAML contains an explicit `initial_state` value, it overrides the stored state after a restart (`true` forces on, `false` forces off regardless of stored state).
 
 ### Method 2: Registry Disable (Permanent, via Entity Registry)
 
-Disabling an automation via *Settings → Automations → ⋮ → Show settings → Enabled toggle* sets `disabled_by: user` in `core.entity_registry`. The entity is removed from the state machine entirely.
+Disabling an automation via *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* sets `disabled_by: user` in `core.entity_registry`. The entity is removed from the state machine entirely.
 
 | Attribute | Value |
 | --- | --- |
 | Survives reload? | Yes — stored in `core.entity_registry` |
 | Survives restart? | Yes |
 | Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
-| Requires `id:` field? | Yes — only automations with a `unique_id` have a registry entry |
-| Re-enable via | UI toggle (Settings → Automations → Enabled) or `homeassistant.enable_entity` service |
+| Requires `id:` field? | Yes — the `id:` field in `automations.yaml` becomes the automation's `unique_id`, which is required for an entity registry entry |
+| Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update`) |
 
-**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) controls Method 1 (trigger state). The *Settings* panel toggle controls Method 2 (entity registry). These are independent.
+**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *⋮ → Settings* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`.
 
 ### AVOID: `enabled: false` in automations.yaml
 
@@ -652,11 +652,15 @@ Disabling an automation via *Settings → Automations → ⋮ → Show settings 
   triggers: ...
 ```
 
-`enabled:` is **not** a valid top-level key in `automations.yaml`. The schema uses `vol.PREVENT_EXTRA`, so this causes a `FAILED_SCHEMA` validation error and the automation loads as `unavailable`.
+`enabled:` is **not** a valid top-level key in `automations.yaml`. Home Assistant rejects unknown keys during schema validation, so the automation loads as `unavailable`.
 
 ```yaml
-# CORRECT — use the service action instead
+# CORRECT — disable temporarily via service (Method 1)
 action: automation.turn_off
 target:
   entity_id: automation.my_automation
+
+# CORRECT — disable permanently via entity registry (Method 2)
+# UI: Settings → Automations → open automation → ⋮ → Settings → Enabled toggle
+# Or via WebSocket API: config/entity_registry/update (disabled_by: user)
 ```

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -612,11 +612,11 @@ Home Assistant provides two distinct ways to disable an automation, with differe
 `automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` service.
 
 ```yaml
-action: automation.turn_off
-target:
-  entity_id: automation.my_automation
-data:
-  stop_actions: true  # default: true — stops currently running actions
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
+  data:
+    stop_actions: true  # default: true — stops currently running actions
 ```
 
 | Attribute | Value |
@@ -656,9 +656,9 @@ Disabling an automation via *Settings → Automations → open automation → �
 
 ```yaml
 # CORRECT — disable temporarily via service (Method 1)
-action: automation.turn_off
-target:
-  entity_id: automation.my_automation
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
 
 # CORRECT — disable permanently via entity registry (Method 2)
 # UI: Settings → Automations → open automation → ⋮ → Settings → Enabled toggle

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -639,7 +639,7 @@ Disabling an automation via *Settings → Automations → ⋮ → Show settings 
 | Survives restart? | Yes |
 | Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
 | Requires `id:` field? | Yes — only automations with a `unique_id` have a registry entry |
-| Re-enable via | UI only (Settings → Automations → Enabled toggle) |
+| Re-enable via | UI toggle (Settings → Automations → Enabled) or `homeassistant.enable_entity` service |
 
 **Note:** The list toggle on the Automations page (`/config/automation/dashboard`) controls Method 1 (trigger state). The *Settings* panel toggle controls Method 2 (entity registry). These are independent.
 
@@ -660,7 +660,3 @@ action: automation.turn_off
 target:
   entity_id: automation.my_automation
 ```
-
-### AVOID: `enabled: false` on Action Steps (Blueprint instances)
-
-`enabled: false` on action steps inside Blueprint **instances** causes a startup error. Use `if:`/`condition:` in the Blueprint definition instead, or disable the entire automation via the entity registry.

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -9,6 +9,7 @@ This document covers native Home Assistant automation constructs that should be 
 4. [Automation Modes](#automation-modes)
 5. [if/then vs choose](#ifthen-vs-choose)
 6. [Trigger IDs](#trigger-ids)
+7. [Disabling Automations](#disabling-automations)
 
 ---
 
@@ -599,3 +600,67 @@ automation:
 ```
 
 Access trigger info in templates with `trigger.id`, `trigger.entity_id`, `trigger.to_state`, etc.
+
+---
+
+## Disabling Automations
+
+Home Assistant provides two distinct ways to disable an automation, with different persistence and behavior.
+
+### Method 1: Turn Off (Temporary, State Machine)
+
+`automation.turn_off` disables the automation's triggers. The entity remains in the state machine with state `off` and can be re-triggered manually.
+
+```yaml
+action: automation.turn_off
+target:
+  entity_id: automation.my_automation
+data:
+  stop_actions: true  # default: true — stops currently running actions
+```
+
+| Attribute | Value |
+| --- | --- |
+| `stop_actions` | Optional. Stops currently active action runs. **Defaults to `true`.** |
+| Survives reload? | Yes — state is stored in `core.restore_state` |
+| Survives restart? | Only if the automation has an `id:` field (stored in `core.restore_state`) |
+| Entity in state machine? | Yes — state is `off` |
+| Re-enable via | `automation.turn_on` |
+
+**`initial_state` override:** If the automation YAML contains `initial_state: true`, it will override the stored `off` state after a restart.
+
+### Method 2: Registry Disable (Permanent, via Entity Registry)
+
+Disabling an automation via *Settings → Automations → ⋮ → Show settings → Enabled toggle* sets `disabled_by: user` in `core.entity_registry`. The entity is removed from the state machine entirely.
+
+| Attribute | Value |
+| --- | --- |
+| Survives reload? | Yes — stored in `core.entity_registry` |
+| Survives restart? | Yes |
+| Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
+| Requires `id:` field? | Yes — only automations with a `unique_id` have a registry entry |
+| Re-enable via | UI only (Settings → Automations → Enabled toggle) |
+
+**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) controls Method 1 (trigger state). The *Settings* panel toggle controls Method 2 (entity registry). These are independent.
+
+### AVOID: `enabled: false` in automations.yaml
+
+```yaml
+# AVOID — causes FAILED_SCHEMA on load
+- alias: My Automation
+  enabled: false       # not a valid top-level key
+  triggers: ...
+```
+
+`enabled:` is **not** a valid top-level key in `automations.yaml`. The schema uses `vol.PREVENT_EXTRA`, so this causes a `FAILED_SCHEMA` validation error and the automation loads as `unavailable`.
+
+```yaml
+# CORRECT — use the service action instead
+action: automation.turn_off
+target:
+  entity_id: automation.my_automation
+```
+
+### AVOID: `enabled: false` on Action Steps (Blueprint instances)
+
+`enabled: false` on action steps inside Blueprint **instances** causes a startup error. Use `if:`/`condition:` in the Blueprint definition instead, or disable the entire automation via the entity registry.


### PR DESCRIPTION
## Summary

Adds a new "Disabling Automations" section to `references/automation-patterns.md` documenting the two distinct disable mechanisms in Home Assistant.

## Background

Agents frequently encounter two pitfalls when disabling automations:
1. Using `enabled: false` as a top-level YAML key — not valid (`vol.PREVENT_EXTRA` → `FAILED_SCHEMA`)
2. Confusing `automation.turn_off` (temporary, state machine) with the entity registry disable (permanent, removes entity from state machine)

## Changes

### `references/automation-patterns.md`
- New section "Disabling Automations" with comparison table for both methods
- Covers `stop_actions` default (`true`), `initial_state` override behavior, and AVOID patterns
- TOC entry added

### `skills/home-assistant-best-practices/SKILL.md`
- Anti-pattern entry: `enabled: false` top-level → `FAILED_SCHEMA`
- Reference anchor `#disabling-automations` added to automation-patterns.md table row

## Verification

- `vol.PREVENT_EXTRA` in `make_script_schema`: verified in homeassistant/core automation/config.py
- `DEFAULT_STOP_ACTIONS = True`: verified in automation/const.py
- `initial_state` override logic: verified in automation/__init__.py L745
- Registry disable (`disabled_by: user`) → entity removed from state machine: live-tested on HA 2026.3.3