### PR TITLE
docs(best-practices): update skill for HA 2025.9–2026.4

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -103,6 +103,9 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Searching for or reading HA config files on disk | Use the HA REST/WebSocket API to manage config programmatically | HA is a remote system accessed via APIs; config files are not on the local filesystem | — |
 | Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
 | Telling user to edit `configuration.yaml` for integrations | Direct user to Settings > Devices & Services in the HA UI | Most integrations are UI-configured; YAML integration config is rare and integration-specific | — |
+| Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
+| `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
+| Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
 
 ---
 
@@ -113,7 +116,7 @@ Read these when you need detailed information:
 | File | When to read | Key sections |
 |------|--------------|--------------|
 | `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
-| `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes; disabling automations | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#ifthen-vs-choose`, `#trigger-ids`, `#disabling-automations` |
+| `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes; disabling automations | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#continue-on-error`, `#repeat-actions`, `#ifthen-vs-choose`, `#trigger-ids`, `#disabling-automations` |
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |
 | `references/device-control.md` | Writing service calls, Zigbee button automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#zigbee-buttonremote-patterns`, `#domain-specific-patterns` |

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -7,9 +7,11 @@ This document covers native Home Assistant automation constructs that should be 
 2. [Trigger Types](#trigger-types)
 3. [Wait Actions](#wait-actions)
 4. [Automation Modes](#automation-modes)
-5. [if/then vs choose](#ifthen-vs-choose)
-6. [Trigger IDs](#trigger-ids)
-7. [Disabling Automations](#disabling-automations)
+5. [Continue on Error](#continue-on-error)
+6. [Repeat Actions](#repeat-actions)
+7. [if/then vs choose](#ifthen-vs-choose)
+8. [Trigger IDs](#trigger-ids)
+9. [Disabling Automations](#disabling-automations)
 
 ---
 
@@ -202,6 +204,16 @@ conditions:
 ---
 
 ## Trigger Types
+
+### Purpose-Specific Triggers (2026.2+)
+
+The HA visual automation editor offers **purpose-specific triggers and conditions** organized by real-world concepts (door opened, motion detected, temperature threshold, battery low, etc.) rather than by technical entity domain. These work across entity types — e.g., "when a door opens" fires whether the door is a contact sensor or a motorized cover.
+
+**Key points:**
+- This is a **UI editor feature** — under the hood, it generates standard `state`, `numeric_state`, and other trigger types
+- No new YAML trigger syntax — the YAML output uses the same triggers documented below
+- Available concepts: door/window/gate open/close, motion/occupancy detection, temperature/humidity/illuminance thresholds, power consumption, battery status, air quality, climate, and more
+- When creating automations via the API, use the standard YAML trigger types below
 
 ### State Trigger
 
@@ -504,6 +516,77 @@ automation:
     mode: single
     max_exceeded: silent  # No warning logged
 ```
+
+---
+
+## Continue on Error
+
+Any automation action can be set to continue execution even if it fails, using the `continue_on_error` key. Since 2026.3, this is also configurable in the visual editor (three-dots menu on any action).
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.patio
+    continue_on_error: true  # Automation proceeds even if this fails
+  - action: notify.mobile_app
+    data:
+      message: "Light action attempted"
+```
+
+**Use sparingly** — silently swallowing errors makes debugging harder. Best for non-critical actions (e.g., logging, optional notifications) where a failure shouldn't block the rest of the automation.
+
+---
+
+## Repeat Actions
+
+Four repeat variants are available:
+
+```yaml
+# Repeat N times
+- repeat:
+    count: 3
+    sequence:
+      - action: light.toggle
+        target:
+          entity_id: light.bedroom
+
+# Repeat while condition is true
+- repeat:
+    while:
+      - condition: state
+        entity_id: binary_sensor.door
+        state: "on"
+    sequence:
+      - action: notify.mobile_app
+        data:
+          message: "Door still open"
+      - delay:
+          minutes: 5
+
+# Repeat until condition is true
+- repeat:
+    until:
+      - condition: numeric_state
+        entity_id: sensor.temperature
+        below: 25
+    sequence:
+      - delay:
+          minutes: 1
+
+# Repeat for each item in a list
+- repeat:
+    for_each:
+      - "light.kitchen"
+      - "light.bedroom"
+      - "light.hallway"
+    sequence:
+      - action: light.turn_off
+        target:
+          entity_id: "{{ repeat.item }}"
+```
+
+Access `repeat.index` (1-based) and `repeat.item` (for `for_each`) inside the sequence.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/dashboard-cards.md
+++ b/skills/home-assistant-best-practices/references/dashboard-cards.md
@@ -1,10 +1,10 @@
 # Dashboard Card Types
 
-Home Assistant provides 37 built-in card types. For card-specific documentation, fetch from GitHub on demand.
+Home Assistant provides 38 built-in card types. For card-specific documentation, fetch from GitHub on demand.
 
 ## Available Card Types
 
-alarm-panel, area, button, calendar, clock, conditional, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
+alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
 
 **Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See `references/dashboard-guide.md#view-types`.
 
@@ -30,6 +30,7 @@ If the MCP server registers resource URI templates for card docs, prefer those o
 | Room overview with controls | `area` |
 | Historical data graph | `history-graph` or `statistics-graph` |
 | Sensor value display | `sensor` or `gauge` |
+| Proportional data across entities | `distribution` |
 | Show/hide cards conditionally | `conditional` |
 | Embed external page | `iframe` |
 | Rich text / instructions | `markdown` |

--- a/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -84,10 +84,10 @@ Patterns and decisions for designing Home Assistant Lovelace dashboards.
 | **Modern Primary** | tile, area, button, grid |
 | **Container** | vertical-stack, horizontal-stack, grid |
 | **Logic** | conditional, entity-filter |
-| **Display** | sensor, history-graph, statistics-graph, gauge, energy, calendar |
+| **Display** | sensor, history-graph, statistics-graph, gauge, energy, calendar, distribution |
 | **Legacy Control** | entity, entities, light, thermostat (use tile instead) |
 
-**Default:** Use `tile` card for most entities. Use `references/dashboard-cards.md` to look up all 37 card types or fetch card-specific docs.
+**Default:** Use `tile` card for most entities. Use `references/dashboard-cards.md` to look up all card types or fetch card-specific docs.
 
 ### Tile Card
 
@@ -133,7 +133,15 @@ Quick controls available on tile, area, humidifier, and thermostat cards.
 | Cover | `cover-open-close`, `cover-position`, `cover-tilt` |
 | Fan | `fan-speed`, `fan-direction`, `fan-oscillate` |
 | Media | `media-player-playback`, `media-player-volume-slider` |
-| Other | `toggle`, `button`, `alarm-modes`, `lock-commands`, `numeric-input` |
+| Valve | `valve-open-close`, `valve-position` |
+| Other | `toggle`, `button`, `alarm-modes`, `lock-commands`, `numeric-input`, `datetime-picker` |
+
+### Tile Card Extras (2025.9+)
+
+Tile cards support additional display features beyond controls:
+- **Trend graph**: 24-hour history sparkline for numeric entities (enabled in tile card config)
+- **Bar gauge**: Percentage-based bar display for numeric entities
+- **Action buttons**: Run automations/scripts directly from tile cards
 
 Feature `style` options: `"dropdown"` or `"icons"`
 
@@ -359,6 +367,15 @@ Search HACS for community cards by name/category, review repository details, the
 - Use **grid** cards for multi-column layouts within sections
 - Create **multiple views** with navigation paths (avoid single-view endless scrolling)
 - Use **area** cards with navigation for hierarchical organization
+
+### Recent Dashboard Features (2026.2–2026.4)
+
+| Feature | Version | Details |
+|---------|---------|---------|
+| **Distribution card** | 2026.2 | Proportional horizontal bars across multiple entities (power monitoring, storage usage) |
+| **Section background colors** | 2026.4 | Sections support custom `background_color` with adjustable opacity |
+| **Card favorites** | 2026.4 | Light color favorites and cover position favorites display on tile/light cards |
+| **Auto-height cards** | 2026.4 | Cards auto-adjust height based on content via the layout editor |
 
 **Legacy patterns to avoid:**
 - Single-view dashboards with all cards in one long scroll

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -168,6 +168,8 @@ triggers:
 
 ### Lights
 
+**Color temperature:** Always use `color_temp_kelvin` (e.g., `3000`). The legacy `color_temp` parameter (in mireds) was removed in 2026.3.
+
 ```yaml
 # Turn on with brightness and transition
 actions:
@@ -299,17 +301,20 @@ actions:
     target:
       entity_id: vacuum.roborock
 
-# Clean specific rooms (integration-specific)
+# Clean specific areas (2026.3+ — uses HA areas, not vendor room IDs)
+# Requires mapping vacuum segments to HA areas in entity settings first
+# Supported integrations include Matter, Ecovacs, Roborock (list may grow)
 actions:
-  - action: vacuum.send_command
+  - action: vacuum.clean_area
     target:
       entity_id: vacuum.roborock
     data:
-      command: app_segment_clean
-      params:
-        - 16  # Room ID
-        - 17
+      area_id:
+        - kitchen
+        - living_room
 ```
+
+**Prefer `vacuum.clean_area` over `vacuum.send_command`** when the user has mapped vacuum segments to HA areas (entity settings). It works across supported integrations without vendor lock-in. Fall back to `vacuum.send_command` if the integration is unsupported or segments are not yet mapped — and suggest the user configure the mapping.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -314,7 +314,24 @@ actions:
         - living_room
 ```
 
-**Prefer `vacuum.clean_area` over `vacuum.send_command`** when the user has mapped vacuum segments to HA areas (entity settings). It works across supported integrations without vendor lock-in. Fall back to `vacuum.send_command` if the integration is unsupported or segments are not yet mapped — and suggest the user configure the mapping.
+**Prefer `vacuum.clean_area`** when the user has mapped vacuum segments to HA areas (entity settings). It works across supported integrations without vendor lock-in.
+
+**Fallback:** When the integration doesn't support `clean_area` or segments aren't mapped, use `vacuum.send_command` with integration-specific parameters:
+
+```yaml
+# Integration-specific room cleaning (fallback)
+actions:
+  - action: vacuum.send_command
+    target:
+      entity_id: vacuum.roborock
+    data:
+      command: app_segment_clean
+      params:
+        - 16  # Vendor-specific room ID
+        - 17
+```
+
+Suggest the user configure segment-to-area mapping when possible to avoid vendor lock-in.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -600,6 +600,8 @@ automation:
 | `is_state('entity_id', 'state')` | Check if entity has state |
 | `is_state_attr('entity_id', 'attr', 'value')` | Check attribute value |
 | `has_value('entity_id')` | True if not unknown/unavailable |
+| `entity_name('entity_id')` | Get entity display name; preferred over `friendly_name` attribute (2026.4+) |
+| `state_attr_translated('entity_id', 'attr')` | Get translated attribute value, e.g., fan modes, HVAC actions (2026.4+) |
 
 ### Common Filters
 


### PR DESCRIPTION
## What does this PR do?

Updates the `home-assistant-best-practices` skill with new features, breaking changes, and terminology from Home Assistant releases 2025.9 through 2026.4.

### Anti-patterns added (SKILL.md)
- **Add-ons → Apps** — HA renamed add-ons to "Apps" in 2026.2
- **`vacuum.send_command` → `vacuum.clean_area`** — native HA area-based cleaning (2026.3), with fallback guidance when segments aren't mapped
- **`color_temp` (mireds) → `color_temp_kelvin`** — mireds parameter removed in 2026.3

### Automation patterns (automation-patterns.md)
- **Purpose-specific triggers** — documents the UI editor abstraction (2026.2+), clarifies it generates standard YAML triggers
- **Continue on error** — `continue_on_error` key with visual editor support since 2026.3
- **Repeat actions** — all four variants: `count`, `while`, `until`, `for_each`
- Updated Table of Contents and SKILL.md reference anchors

### Device control (device-control.md)
- `color_temp_kelvin` migration note with updated examples
- Vacuum section rewritten with `vacuum.clean_area` + fallback to `send_command`

### Template functions (template-guidelines.md)
- `entity_name()` — preferred over `friendly_name` attribute (2026.4+)
- `state_attr_translated()` — translated attribute values for fan modes, HVAC actions (2026.4+)

### Dashboard updates (dashboard-guide.md, dashboard-cards.md)
- **Distribution card** added to card list, categories, and selection guide (2026.2)
- **Tile card extras** — trend graphs, bar gauge, action buttons (2025.9+)
- **New features table** — section backgrounds, card favorites, auto-height cards (2026.2–2026.4)
- Valve and datetime-picker features added to Features table
- Card count updated from 37 → 38

## Checklist

- [ ] Tested with real scenarios (if changing skill content)
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed)