### PR TITLE
docs(best-practices): update skill for HA 2026.5

### DIFF
--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -107,6 +107,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
 | `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
 | Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
+| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `zone` condition | These were removed in 2026.5 — state trigger is the correct replacement | `references/automation-patterns.md#presenceperson-triggers--removed-in-20265` |
 
 ---
 

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -107,7 +107,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
 | `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
 | Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
-| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `zone` condition | These were removed in 2026.5 — state trigger is the correct replacement | `references/automation-patterns.md#presenceperson-triggers--removed-in-20265` |
+| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `state` condition | These were removed in 2026.5 — state triggers and conditions are the correct replacements | `references/automation-patterns.md#presence-and-person-triggers-and-conditions-removed-in-20265` |
 
 ---
 

--- a/skills/home-assistant-best-practices/evals/evals.json
+++ b/skills/home-assistant-best-practices/evals/evals.json
@@ -48,6 +48,54 @@
           "description": "Response does NOT recommend a template sensor (YAML or UI helper) as the primary solution"
         }
       ]
+    },
+    {
+      "id": 4,
+      "eval_name": "arrive-home-automation",
+      "prompt": "create an automation that turns on the lights when I get home",
+      "expected_output": "Uses state trigger with to: home on a person entity. Does NOT use the removed entered_home device trigger type.",
+      "assertions": [
+        {
+          "id": "uses_state_trigger",
+          "description": "Response uses a state trigger (trigger: state) on a person or device_tracker entity, to: home"
+        },
+        {
+          "id": "no_entered_home_trigger",
+          "description": "Response does NOT use the entered_home device trigger type (removed in 2026.5)"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "timer-finished-automation",
+      "prompt": "make an automation that announces on my speaker when my kitchen timer finishes",
+      "expected_output": "Uses timer.finished event trigger. Does NOT use a polling template or state trigger workaround.",
+      "assertions": [
+        {
+          "id": "uses_timer_finished_event",
+          "description": "Response uses event trigger with event_type: timer.finished (or purpose-specific timer trigger)"
+        },
+        {
+          "id": "no_polling_workaround",
+          "description": "Response does NOT suggest polling or a wait_template workaround for detecting timer completion"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "assist-shortcut-card",
+      "prompt": "add a card to my dashboard to quickly launch Assist",
+      "expected_output": "Recommends the shortcut card (new in 2026.5) for launching Assist from a dashboard.",
+      "assertions": [
+        {
+          "id": "recommends_shortcut_card",
+          "description": "Response recommends the shortcut card type for launching Assist"
+        },
+        {
+          "id": "not_just_button_card",
+          "description": "Response does not exclusively recommend a button card with tap_action when shortcut is more appropriate"
+        }
+      ]
     }
   ]
 }

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -367,7 +367,7 @@ triggers:
     subtype: single
 ```
 
-### Presence/Person Triggers — Removed in 2026.5
+### Presence and Person Triggers and Conditions (Removed in 2026.5)
 
 The `entered_home`/`left_home` device trigger types and `is_home`/`is_not_home` device condition types for `person` and `device_tracker` domains were **removed in 2026.5**. Use state triggers and conditions instead.
 

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -367,6 +367,64 @@ triggers:
     subtype: single
 ```
 
+### Presence/Person Triggers — Removed in 2026.5
+
+The `entered_home`/`left_home` device trigger types and `is_home`/`is_not_home` device condition types for `person` and `device_tracker` domains were **removed in 2026.5**. Use state triggers and conditions instead.
+
+```yaml
+# AVOID (removed in 2026.5)
+triggers:
+  - trigger: device
+    domain: person
+    type: entered_home
+    entity_id: person.john
+
+# CORRECT — state trigger
+triggers:
+  - trigger: state
+    entity_id: person.john
+    to: "home"
+
+# CORRECT — state condition
+condition: state
+entity_id: person.john
+state: "home"
+```
+
+For non-home zone presence, see `#zone-condition`.
+
+### Timer Entity Triggers (2026.5+)
+
+Timer entities now expose lifecycle events as purpose-specific triggers in the UI editor. In YAML, use the `event` trigger with the corresponding `timer.*` event type.
+
+```yaml
+# Timer finished (also: timer.started, timer.paused, timer.restarted, timer.cancelled)
+triggers:
+  - trigger: event
+    event_type: timer.finished
+    event_data:
+      entity_id: timer.cooking
+```
+
+### Media Player Triggers/Conditions (2026.5+)
+
+Media player entities now have purpose-specific triggers and conditions in the UI editor covering play/pause state, mute status, and volume level. In YAML these map to standard state and numeric_state triggers.
+
+```yaml
+# Play/pause state — to: "playing", "paused", "idle", "off"
+triggers:
+  - trigger: state
+    entity_id: media_player.living_room
+    to: "playing"
+
+# Volume threshold
+triggers:
+  - trigger: numeric_state
+    entity_id: media_player.living_room
+    attribute: volume_level
+    above: 0.7
+```
+
 ---
 
 ## Wait Actions

--- a/skills/home-assistant-best-practices/references/dashboard-cards.md
+++ b/skills/home-assistant-best-practices/references/dashboard-cards.md
@@ -1,10 +1,10 @@
 # Dashboard Card Types
 
-Home Assistant provides 38 built-in card types. For card-specific documentation, fetch from GitHub on demand.
+Home Assistant provides 39 built-in card types. For card-specific documentation, fetch from GitHub on demand.
 
 ## Available Card Types
 
-alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
+alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, shortcut, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
 
 **Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See `references/dashboard-guide.md#view-types`.
 
@@ -26,7 +26,7 @@ If the MCP server registers resource URI templates for card docs, prefer those o
 |------|------|
 | Control any entity | `tile` (modern default) |
 | Layout multiple cards in columns | `grid` |
-| Navigation button | `button` with `tap_action: navigate` |
+| Navigation button or Assist launcher | `shortcut` (2026.5+) or `button` with `tap_action: navigate` |
 | Room overview with controls | `area` |
 | Historical data graph | `history-graph` or `statistics-graph` |
 | Sensor value display | `sensor` or `gauge` |


### PR DESCRIPTION
## What does this PR do?

Updates the `home-assistant-best-practices` skill with breaking changes and new patterns from HA 2026.5.

**Breaking change (anti-pattern added):**
- `entered_home`/`left_home` device triggers and `is_home`/`is_not_home` conditions for `person`/`device_tracker` were removed in 2026.5. New anti-pattern row in SKILL.md points to the migration guide.

**New sections in `references/automation-patterns.md`:**
- Presence/Person Triggers — Removed in 2026.5 (before/after YAML, cross-ref to zone condition)
- Timer Entity Triggers (2026.5+) — `timer.finished/started/paused/restarted/cancelled` via event trigger
- Media Player Triggers/Conditions (2026.5+) — play/pause state and volume threshold via native triggers

**Dashboard (`references/dashboard-cards.md`):**
- Added `shortcut` card to the available card type list (39 total)
- Updated Quick Card Selection Guide: shortcut card recommended for navigation/Assist launcher use case

**Evals (`evals/evals.json`):**
- 3 new test cases: arrive-home automation, timer-finished automation, Assist shortcut card

## Checklist

- [x] Tested with real scenarios (if changing skill content)
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed)