### PR TITLE
docs(yaml-only-integrations): correct reload services and tighten scope

### DIFF
--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -2,12 +2,9 @@
 
 Use managed YAML config editing (with backup, validation, and `check_config` verification) for integrations that have no config flow and no REST/WebSocket API for creation.
 
-This does NOT apply to:
-- Automations/scripts/scenes (use config APIs)
-- UI-configured integrations and helpers (config flow) — including `template` (Template Helper), `group` (Group Helper), `input_*` helpers, and most modern notify integrations
-- `.storage/` files (use REST/WebSocket APIs)
+This does NOT apply to automations/scripts/scenes (use config APIs), UI-configured integrations and helpers (config flow) — including `template` (Template Helper), `group` (Group Helper), `input_*` helpers, and most modern notify integrations — or `.storage/` files (use REST/WebSocket APIs).
 
-For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Discord, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
+For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Telegram, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
 
 ## YAML-Only Integration Types
 

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -2,9 +2,15 @@
 
 Use managed YAML config editing (with backup, validation, and `check_config` verification) for integrations that have no config flow and no REST/WebSocket API for creation.
 
-This does NOT apply to automations/scripts/scenes (use config APIs), UI-configured integrations and helpers (config flow) — including `template` (Template Helper), `group` (Group Helper), `input_*` helpers, and most modern notify integrations — or `.storage/` files (use REST/WebSocket APIs).
+This does NOT apply to:
 
-For sending notifications, prefer config-flow notify integrations (Mobile App, Telegram, MQTT, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
+- Automations/scripts/scenes (use config APIs)
+- `.storage/` files (use REST/WebSocket APIs)
+- UI-configured integrations and helpers (config flow): `template` (Template Helper), `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations
+
+Old-style YAML `group:` blocks are still YAML-only and appear in the table below — only the UI Group Helper is excluded.
+
+For sending notifications, prefer config-flow notify integrations (Mobile App, Telegram, etc.) and invoke them via their `notify.<integration_name>` action (e.g. `notify.mobile_app_phone`) from automations — not a YAML `notify:` platform definition.
 
 ## YAML-Only Integration Types
 
@@ -15,7 +21,7 @@ For sending notifications, prefer config-flow notify integrations (Mobile App, T
 | `shell_command` | `shell_command.reload` | Named shell command definitions |
 | `mqtt` (platform-based) | `mqtt.reload` | Platform-style `mqtt:` sensors/switches. MQTT Discovery and MQTT device config entries are non-YAML alternatives for auto-published devices |
 | `group` (YAML-defined) | `group.reload` | Old-style YAML groups. Prefer the UI Group Helper (Settings → Devices & Services → Helpers → Group) for new groups |
-| `sensor` / `binary_sensor` (platform-style) | Restart required | Platform-style YAML definitions (e.g. `sensor: - platform: xyz`) for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
-| `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | Restart required | Same as above — only for platforms that have no config flow |
+| `sensor` / `binary_sensor` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `sensor:` (or `binary_sensor:`) key with a block sequence of `- platform: <name>` entries — for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
+| `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `switch:` / `light:` / etc. key with a block sequence of `- platform: <name>` entries — only for platforms that have no config flow. Check the integration's docs before assuming YAML is required |
 
-Confirm with the user before triggering a restart — it briefly interrupts all automations and integrations.
+Confirm with the user before triggering `homeassistant.restart` — it briefly interrupts all automations and integrations.

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -4,10 +4,10 @@ Use managed YAML config editing (with backup, validation, and `check_config` ver
 
 This does NOT apply to:
 - Automations/scripts/scenes (use config APIs)
-- UI-configured integrations and helpers (config flow) — including `template` (Template Helper), groups (Group Helper), `input_*` helpers, and most modern notify integrations
+- UI-configured integrations and helpers (config flow) — including `template` (Template Helper), `group` (Group Helper), `input_*` helpers, and most modern notify integrations
 - `.storage/` files (use REST/WebSocket APIs)
 
-For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Telegram, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
+For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Discord, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
 
 ## YAML-Only Integration Types
 

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -6,7 +6,7 @@ This does NOT apply to:
 
 - Automations/scripts/scenes (use config APIs)
 - `.storage/` files (use REST/WebSocket APIs)
-- UI-configured integrations and helpers (config flow): `template` (Template Helper), `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations
+- UI-configured integrations and helpers (config flow): `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations
 
 Old-style YAML `group:` blocks are still YAML-only and appear in the table below — only the UI Group Helper is excluded.
 
@@ -16,6 +16,7 @@ For sending notifications, prefer config-flow notify integrations (Mobile App, T
 
 | Integration type | Post-edit action | Notes |
 |---|---|---|
+| `template` | `template.reload` | Simple template entities: prefer the UI Template Helper. Trigger-based templates and multi-entity blocks (shared triggers/variables) still require YAML. |
 | `command_line` | `command_line.reload` | Sensors, switches, binary sensors via shell commands |
 | `rest` | `rest.reload` | REST sensors, binary sensors |
 | `shell_command` | `shell_command.reload` | Named shell command definitions |

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -2,20 +2,23 @@
 
 Use managed YAML config editing (with backup, validation, and `check_config` verification) for integrations that have no config flow and no REST/WebSocket API for creation.
 
-This does NOT apply to automations/scripts/scenes (use config APIs), UI-configured integrations, `.storage/` files (use REST/WebSocket APIs), or helpers like input_number/input_boolean (these have config flow).
+This does NOT apply to:
+- Automations/scripts/scenes (use config APIs)
+- UI-configured integrations and helpers (config flow) — including `template` (Template Helper), groups (Group Helper), `input_*` helpers, and most modern notify integrations
+- `.storage/` files (use REST/WebSocket APIs)
+
+For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Telegram, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
 
 ## YAML-Only Integration Types
 
 | Integration type | Post-edit action | Notes |
 |---|---|---|
-| `template` | Reload available | Prefer Template Helper (UI) when possible |
-| `mqtt` (platform-based) | Reload available | Platform-style `mqtt:` sensors/switches; MQTT devices via config entry are separate |
-| `group` (YAML-defined) | Reload available | Groups defined in YAML; UI groups use config entries |
-| `command_line` | Restart required | Sensors, switches, binary sensors via shell commands |
-| `rest` | Restart required | REST sensors, binary sensors |
-| `shell_command` | Restart required | Named shell command definitions |
-| `notify` (legacy platform-based) | Restart required | Most notify platforms now use config entries; only legacy platform-based definitions are YAML-only |
-| `sensor` / `binary_sensor` | Restart required | Platform-style YAML definitions (e.g. `sensor: platform: xyz`) |
-| `switch` / `light` / `fan` / `cover` / `climate` | Restart required | Platform-based YAML definitions |
+| `command_line` | `command_line.reload` | Sensors, switches, binary sensors via shell commands |
+| `rest` | `rest.reload` | REST sensors, binary sensors |
+| `shell_command` | `shell_command.reload` | Named shell command definitions |
+| `mqtt` (platform-based) | `mqtt.reload` | Platform-style `mqtt:` sensors/switches. MQTT Discovery and MQTT device config entries are non-YAML alternatives for auto-published devices |
+| `group` (YAML-defined) | `group.reload` | Old-style YAML groups. Prefer the UI Group Helper (Settings → Devices & Services → Helpers → Group) for new groups |
+| `sensor` / `binary_sensor` (platform-style) | Restart required | Platform-style YAML definitions (e.g. `sensor: - platform: xyz`) for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
+| `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | Restart required | Same as above — only for platforms that have no config flow |
 
 Confirm with the user before triggering a restart — it briefly interrupts all automations and integrations.

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -4,7 +4,7 @@ Use managed YAML config editing (with backup, validation, and `check_config` ver
 
 This does NOT apply to automations/scripts/scenes (use config APIs), UI-configured integrations and helpers (config flow) — including `template` (Template Helper), `group` (Group Helper), `input_*` helpers, and most modern notify integrations — or `.storage/` files (use REST/WebSocket APIs).
 
-For sending notifications, prefer config-flow notify integrations (Mobile App, Pushover, Telegram, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
+For sending notifications, prefer config-flow notify integrations (Mobile App, Telegram, MQTT, etc.) with the `notify.send_message` action from automations — not a YAML `notify:` platform definition.
 
 ## YAML-Only Integration Types
 


### PR DESCRIPTION
## What does this PR do?

Corrects factual errors and clarifies scope in `references/yaml-only-integrations.md`.

**Confirmed factual errors (`Restart required` → `*.reload` service available):**
- `command_line` — has `command_line.reload` ([docs](https://www.home-assistant.io/integrations/command_line/#actions))
- `rest` — has `rest.reload` (`homeassistant/components/rest/services.yaml`)
- `shell_command` — has `shell_command.reload` ([docs](https://www.home-assistant.io/integrations/shell_command/#reload))

**Rows removed (not actually YAML-only):**
- `template` — has UI Template Helper (config flow). `SKILL.md` already directs users to the Template Helper for new template entities.
- `notify` (legacy platform-based) — most modern notify integrations use config flow; the right pattern is `notify.send_message` from automations against a config-flow notify integration. Moved guidance to the intro.

**Other refinements:**
- Post-edit action column now shows the actual reload service name (e.g. `command_line.reload`) instead of generic "Reload available".
- Reordered so true YAML-only integrations sit at the top, partial / catch-all rows at the bottom.
- Expanded intro exclusions list to call out Template Helper, Group Helper, and modern notify integrations explicitly.
- Added caveat on `sensor`/`binary_sensor`/`switch`/`light`/etc. platform-style rows — many specific platforms now have config flows.

## Checklist

- [x] Tested with real scenarios (if changing skill content) — verified each reload service against `homeassistant/components/<integration>/services.yaml` in home-assistant/core and the integration's published docs
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed) — no reference files added/removed