### PR TITLE
fix: cmd to install plugin in claude code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run each command separately inside Claude Code:
 /plugin marketplace add homeassistant-ai/skills
 ```
 ```
-/plugin install home-assistant-skills@homeassistant-ai-skills
+/plugin install home-assistant-skills@home-assistant-skills
 ```
 
 Run `/reload-plugins` or restart Claude Code for the skill to take effect.


### PR DESCRIPTION
## What does this PR do?

The README's install command references a marketplace named homeassistant-ai-skills, but `/plugin marketplace add homeassistant-ai/skills` registers it as `home-assistant-skills` (the name field in `marketplace.json`). The `<plugin>@<marketplace>` spec therefore fails with Marketplace "homeassistant-ai-skills" not found.

## Checklist

- [X] Tested with real scenarios (if changing skill content)
- [X] `README.md` Skill Contents table updated (if reference files were added or removed)
