### PR TITLE
fix(marketplace): set owner.email so Copilot CLI accepts marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "home-assistant-skills",
   "owner": {
     "name": "homeassistant-ai",
-    "email": ""
+    "email": "homeassistant-mcp@qc-h.net"
   },
   "metadata": {
     "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, device control, and dashboards",


### PR DESCRIPTION
## What does this PR do?

Sets `owner.email` in `.claude-plugin/marketplace.json` to the contact
address published in the `homeassistant-ai` org profile
(`homeassistant-mcp@qc-h.net`), so the file validates against stricter
marketplace.json schemas — notably the one used by **GitHub Copilot CLI**.

Fixes #53.

### Background

The current value is an empty string:

```json
"owner": { "name": "homeassistant-ai", "email": "" }
```

Claude Code treats `owner.email` as optional, but Copilot CLI's validator
requires a syntactically valid email. The result:

```console
$ copilot plugin marketplace add homeassistant-ai/skills
Failed to add marketplace: Invalid marketplace.json: owner.email: Invalid email
```

Users on Copilot CLI are forced onto the deprecated direct-install path,
which will be removed in a future release — at which point this repo
becomes uninstallable from Copilot CLI.

### Change

One-line edit:

```diff
-    "email": ""
+    "email": "homeassistant-mcp@qc-h.net"
```

Verified locally with `copilot plugin marketplace add` against the patched
file — the marketplace registers and `home-assistant-skills` installs
cleanly via `plugin@marketplace`.

If maintainers prefer a different address (a different project list, an
existing maintainer's noreply, etc.), feel free to amend before merge —
the structural fix is what matters.

## Checklist

- [x] Tested with real scenarios (if changing skill content)  — N/A, no skill content changed; tested with Copilot CLI marketplace add
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)  — N/A
