### PR TITLE
docs(best-practices): document initial resets state on every HA restart

### DIFF
--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -401,7 +401,7 @@ sensor:
 **Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, and `input_select` all accept an `initial` field. If `initial` is present in the config (any value, including `false` or `0`), HA forces that value on every restart instead of restoring the last saved state.
 - Omit `initial` to preserve state across restarts.
 - Use `initial` only when the helper must always start at a fixed value.
-- To remove `initial` from an existing helper, delete and recreate it — the HA UI has no option to clear it.
+- Once `initial` is set, `ha_config_set_helper` updates preserve it; delete and recreate the helper to clear it.
 
 ### input_boolean
 

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -398,6 +398,11 @@ sensor:
 
 ## State Storage
 
+**Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, and `input_select` all accept an `initial` field. If `initial` is present in the config (any value, including `false` or `0`), HA forces that value on every restart instead of restoring the last saved state.
+- Omit `initial` to preserve state across restarts.
+- Use `initial` only when the helper must always start at a fixed value.
+- To remove `initial` from an existing helper, delete and recreate it — the HA UI has no option to clear it.
+
 ### input_boolean
 
 **Use for:** Toggle switches for modes, flags, and conditions.

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -401,7 +401,6 @@ sensor:
 **Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, and `input_select` all accept an `initial` field. If `initial` is present in the config (any value, including `false` or `0`), HA forces that value on every restart instead of restoring the last saved state.
 - Omit `initial` to preserve state across restarts.
 - Use `initial` only when the helper must always start at a fixed value.
-- Once `initial` is stored, delete and recreate the helper to remove it.
 
 ### input_boolean
 

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -401,7 +401,7 @@ sensor:
 **Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, and `input_select` all accept an `initial` field. If `initial` is present in the config (any value, including `false` or `0`), HA forces that value on every restart instead of restoring the last saved state.
 - Omit `initial` to preserve state across restarts.
 - Use `initial` only when the helper must always start at a fixed value.
-- Once `initial` is set, `ha_config_set_helper` updates preserve it; delete and recreate the helper to clear it.
+- Once `initial` is stored, delete and recreate the helper to remove it.
 
 ### input_boolean
 


### PR DESCRIPTION
## What does this PR do?

Adds a pitfall note to the `## State Storage` section of `references/helper-selection.md` documenting that the `initial` field in `input_boolean`, `input_number`, and `input_select` suppresses state restoration on every HA restart — not just the first boot.

**Root cause (verified against HA core):** when `initial` is present in the helper config, `async_added_to_hass` returns early and skips `async_get_last_state()`, forcing the configured value on every restart. Omitting `initial` is the correct way to preserve the last saved state.

Closes homeassistant-ai/ha-mcp#1682.

## Checklist

- [x] Tested with real scenarios (if changing skill content)
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)