### PR TITLE
ci: fix skill version-bump filter and harden auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -31,6 +31,11 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         continue-on-error: true
 
+      - name: Warn if app token unavailable
+        if: steps.app-token.outcome == 'failure'
+        run: |
+          echo "::warning::GitHub App token generation failed — falling back to GITHUB_TOKEN. If branch protection requires the app identity, the commit-and-push step will fail; check the RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY secrets."
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -71,9 +76,11 @@ jobs:
             skill_md="${skill_dir}/SKILL.md"
             [ -f "$skill_md" ] || continue
 
-            # Skip if the only diff is the version field itself (e.g. a standalone format migration)
+            # Skip if the only diff is the version field itself (e.g. a standalone format migration).
+            # Anchor the version filter to the frontmatter field so substrings like `min_version:`
+            # in skill content aren't mistaken for the version line and dropped from the diff.
             content_diff=$(git diff "$BEFORE_SHA" HEAD -- "$skill_dir" \
-              | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -v 'version:' || true)
+              | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -vE '^[+-][[:space:]]*version:' || true)
             if [ -z "$content_diff" ]; then
               echo "Skipping ${skill_dir}: no content changes beyond version field"
               continue
@@ -104,7 +111,10 @@ jobs:
                 m=0
               }
               {print}
-            ' "$skill_md" > "${skill_md}.tmp" && mv "${skill_md}.tmp" "$skill_md"
+            ' "$skill_md" > "${skill_md}.tmp"
+            # Separate statement (not `awk && mv`) so a failing awk trips `set -e`
+            # instead of silently skipping the mv and reporting a false "Bumped".
+            mv "${skill_md}.tmp" "$skill_md"
 
             echo "Bumped ${skill_md}: ${current} -> ${new_version}"
             any_bumped=true


### PR DESCRIPTION
## What does this PR do?

Fixes a false-negative in the auto-bump workflow's content-diff filter, plus two robustness gaps in the same job.

**The bug:** the filter used `grep -v 'version:'`, which drops *every* diff line containing the substring `version:` — not just the frontmatter field. A skill change touching only lines like `min_version:` (e.g. in `references/blueprint-guide.md`) was misclassified as a version-only change, so `metadata.version` was never bumped and `/plugin update` silently no-op'd for real content changes. The filter is now anchored to the frontmatter field: `^[+-][[:space:]]*version:`.

**Also hardened:**
- Split `awk ... > tmp && mv` into separate statements so a failing `awk` trips `set -e` instead of skipping the `mv` and logging a false "Bumped".
- Emit a `::warning::` when app-token generation falls back to `GITHUB_TOKEN`, so the root cause surfaces up front instead of as a confusing push failure later.

**Validation:** `shellcheck` clean on the changed steps; both bash-logic fixes proven by side-by-side simulation (old buggy behavior vs. new); workflow YAML parses.

## Checklist

- [ ] Tested with real scenarios (if changing skill content) — N/A, CI-only change
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed) — N/A
