### PR TITLE
feat(best-practices): add backups and recovery reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `home-assistant-best-practices` skill includes:
 | `references/examples.yaml` | Compound examples combining multiple best practices |
 | `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact |
 | `references/blueprint-guide.md` | Blueprint authoring: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, `!input` templating, versioning |
-| `references/backups.md` | Full instance backups vs config-level rollback, when an operation needs a backup first, restore consequences, backup-deletion guards |
+| `references/backups.md` | Full instance backups vs rolling one object back, when an operation needs a backup first, what an archive contains, encryption keys, restore verification, backup deletion |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The `home-assistant-best-practices` skill includes:
 | `references/examples.yaml` | Compound examples combining multiple best practices |
 | `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact |
 | `references/blueprint-guide.md` | Blueprint authoring: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, `!input` templating, versioning |
+| `references/backups.md` | Full instance backups vs config-level rollback, when an operation needs a backup first, restore consequences, backup-deletion guards |
 
 ## Contributing
 

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -122,6 +122,8 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Free-text input for an entity/device in a Blueprint | Typed `entity`/`target`/`device` selector | Text lets typos through and fails silently; selectors validate the choice | `references/blueprint-guide.md#inputs-and-selectors` |
 | `!input` used directly inside a template | Bind it to a `variables:` entry, use the variable | `!input` is a YAML tag, not a template value — the template errors or ignores it | `references/blueprint-guide.md#referencing-inputs-input-and-templating` |
 | Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
+| Full instance restore to undo one automation/script/scene/dashboard/helper edit | Write the previous definition back (config-level rollback) | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-layer` |
+| Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterwards captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
 
 ---
 
@@ -144,3 +146,4 @@ Read these when you need detailed information:
 | `references/examples.yaml` | Need compound examples combining multiple best practices | — |
 | `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact | — |
 | `references/blueprint-guide.md` | Authoring reusable blueprints: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, input sections, `!input` templating, versioning | `#when-to-author-a-blueprint`, `#blueprint-metadata`, `#inputs-and-selectors`, `#target-selector-vs-entity-selector`, `#defaults`, `#input-sections`, `#referencing-inputs-input-and-templating`, `#versioning-and-updates`, `#common-pitfalls` |
+| `references/backups.md` | Deciding whether an operation needs a backup first, choosing between a full instance restore and config-level rollback, restore consequences and post-restore verification, why deleting backups is guarded | `#which-recovery-layer`, `#when-a-full-backup-earns-its-cost`, `#what-a-full-backup-contains`, `#restoring-consequences-and-verification`, `#why-deleting-backups-is-guarded`, `#common-pitfalls` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -9,10 +9,10 @@ description: >
   - Restructuring triggers, conditions, or modes
   - Zigbee button/remote automations
   - Renaming entities or migrating device_id to entity_id
-  - Looking up card types, domain docs, or selecting helpers
+  - Looking up card types or domain docs
   - AppDaemon apps
   - Authoring reusable Blueprints
-  - Backing up, restoring, or rolling back a change
+  - About to delete, restore, or upgrade with no undo
 
   SYMPTOMS:
   - Agent uses Jinja2 templates where native options exist
@@ -23,7 +23,7 @@ description: >
   - Agent edits .storage, writes YAML, or generates YAML snippets
   - Agent tells user to edit configuration.yaml for UI integrations
   - Agent hardcodes Blueprint entities or uses free-text over a selector
-  - Agent runs an irreversible change with no recovery point
+  - Agent changes existing state with no recovery path
 metadata:
   version: 16
 ---
@@ -125,8 +125,8 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
 | Full instance restore to undo one automation/script/scene/dashboard/helper edit | Roll that object back — write its previous definition back through the config API | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-path` |
 | Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterward captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
-| Restoring a backup, deleting a backup, or upgrading Core without explicit user confirmation | Ask, name what will be lost, and wait for an answer — every time, backup or not | These are irreversible; a backup lowers recovery risk but does not authorize the action | `references/backups.md#deleting-backups` |
-| Calling a service "reversible" without naming its inverse | Treat an operation as reversible only when you can name and target its exact inverse | `vacuum.send_command`, `*.press`, `notify.*`, and anything physical or outbound have no inverse to call | `references/backups.md#when-a-full-backup-earns-its-cost` |
+| Restoring a backup, deleting a backup, or upgrading Core without explicit user confirmation | Ask, name the concrete effect, and wait for an answer — every time, backup or not | Restore discards everything since the archive and restarts HA; deletion destroys a recovery point; a Core/OS upgrade is high-impact and its recovery path IS the pre-upgrade backup | `references/backups.md` |
+| Calling a service "reversible" without naming its inverse | Treat an operation as reversible only when you can name and target its exact inverse | `vacuum.send_command`, `*.press` and `notify.*` have none; and an exact inverse still doesn't undo the consequence — re-locking a door doesn't un-expose the house | `references/backups.md#when-a-full-backup-earns-its-cost` |
 
 ---
 

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -5,14 +5,14 @@ description: >
 
   TRIGGER THIS SKILL WHEN:
   - Creating or editing automations, scripts, scenes, or dashboards
-  - Choosing between template sensors and built-in helpers
-  - Restructuring triggers, conditions, or automation modes
-  - Setting up Zigbee button/remote automations
+  - Choosing template sensors vs built-in helpers
+  - Restructuring triggers, conditions, or modes
+  - Zigbee button/remote automations
   - Renaming entities or migrating device_id to entity_id
-  - Configuring dashboard cards or selecting helpers
-  - Looking up card types or domain docs
-  - Writing or reviewing AppDaemon apps
-  - Authoring or editing reusable Blueprints
+  - Looking up card types, domain docs, or selecting helpers
+  - AppDaemon apps
+  - Authoring reusable Blueprints
+  - Backing up, restoring, or rolling back a change
 
   SYMPTOMS:
   - Agent uses Jinja2 templates where native options exist
@@ -22,7 +22,8 @@ description: >
   - Agent hard-codes values or uses raw sensor over helper
   - Agent edits .storage, writes YAML, or generates YAML snippets
   - Agent tells user to edit configuration.yaml for UI integrations
-  - Agent hardcodes entities in a Blueprint or uses free-text input over a selector
+  - Agent hardcodes Blueprint entities or uses free-text over a selector
+  - Agent runs an irreversible change with no recovery point
 metadata:
   version: 16
 ---
@@ -122,8 +123,10 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Free-text input for an entity/device in a Blueprint | Typed `entity`/`target`/`device` selector | Text lets typos through and fails silently; selectors validate the choice | `references/blueprint-guide.md#inputs-and-selectors` |
 | `!input` used directly inside a template | Bind it to a `variables:` entry, use the variable | `!input` is a YAML tag, not a template value — the template errors or ignores it | `references/blueprint-guide.md#referencing-inputs-input-and-templating` |
 | Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
-| Full instance restore to undo one automation/script/scene/dashboard/helper edit | Write the previous definition back (config-level rollback) | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-layer` |
-| Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterwards captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
+| Full instance restore to undo one automation/script/scene/dashboard/helper edit | Roll that object back — write its previous definition back through the config API | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-path` |
+| Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterward captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
+| Restoring a backup, deleting a backup, or upgrading Core without explicit user confirmation | Ask, name what will be lost, and wait for an answer — every time, backup or not | These are irreversible; a backup lowers recovery risk but does not authorize the action | `references/backups.md#deleting-backups` |
+| Calling a service "reversible" without naming its inverse | Treat an operation as reversible only when you can name and target its exact inverse | `vacuum.send_command`, `*.press`, `notify.*`, and anything physical or outbound have no inverse to call | `references/backups.md#when-a-full-backup-earns-its-cost` |
 
 ---
 
@@ -146,4 +149,4 @@ Read these when you need detailed information:
 | `references/examples.yaml` | Need compound examples combining multiple best practices | — |
 | `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact | — |
 | `references/blueprint-guide.md` | Authoring reusable blueprints: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, input sections, `!input` templating, versioning | `#when-to-author-a-blueprint`, `#blueprint-metadata`, `#inputs-and-selectors`, `#target-selector-vs-entity-selector`, `#defaults`, `#input-sections`, `#referencing-inputs-input-and-templating`, `#versioning-and-updates`, `#common-pitfalls` |
-| `references/backups.md` | Deciding whether an operation needs a backup first, choosing between a full instance restore and config-level rollback, restore consequences and post-restore verification, why deleting backups is guarded | `#which-recovery-layer`, `#when-a-full-backup-earns-its-cost`, `#what-a-full-backup-contains`, `#restoring-consequences-and-verification`, `#why-deleting-backups-is-guarded`, `#common-pitfalls` |
+| `references/backups.md` | Deciding whether an operation needs a backup first; choosing between a full restore, a partial restore, and rolling one object back; what an archive actually contains; encryption keys and the emergency kit; restore verification; what HA does and does not protect when deleting a backup | `#which-recovery-path`, `#when-a-full-backup-earns-its-cost`, `#what-a-full-backup-contains`, `#restoring-consequences-and-verification`, `#deleting-backups`, `#common-pitfalls` |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -12,7 +12,7 @@ description: >
   - Looking up card types or domain docs
   - AppDaemon apps
   - Authoring reusable Blueprints
-  - About to delete, restore, or upgrade with no undo
+  - About to delete a backup, restore a backup, or upgrade Core or the OS
 
   SYMPTOMS:
   - Agent uses Jinja2 templates where native options exist
@@ -125,7 +125,7 @@ See `references/device-control.md#zigbee-buttonremote-patterns`.
 | Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
 | Full instance restore to undo one automation/script/scene/dashboard/helper edit | Roll that object back — write its previous definition back through the config API | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-path` |
 | Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterward captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
-| Restoring a backup, deleting a backup, or upgrading Core without explicit user confirmation | Ask, name the concrete effect, and wait for an answer — every time, backup or not | Restore discards everything since the archive and restarts HA; deletion destroys a recovery point; a Core/OS upgrade is high-impact and its recovery path IS the pre-upgrade backup | `references/backups.md` |
+| Restoring a backup, deleting a backup, or upgrading Core or the OS without explicit user confirmation | Ask, name the concrete effect, and wait for an answer — every time, backup or not | A full restore discards everything since the archive for all restored parts and restarts HA; a Supervisor partial restore overwrites only the selected archive parts; deletion destroys a recovery point; a Core/OS upgrade is high-impact and its recovery path IS the pre-upgrade backup | `references/backups.md` |
 | Calling a service "reversible" without naming its inverse | Treat an operation as reversible only when you can name and target its exact inverse | `vacuum.send_command`, `*.press` and `notify.*` have none; and an exact inverse still doesn't undo the consequence — re-locking a door doesn't un-expose the house | `references/backups.md#when-a-full-backup-earns-its-cost` |
 
 ---

--- a/skills/home-assistant-best-practices/references/backups.md
+++ b/skills/home-assistant-best-practices/references/backups.md
@@ -1,89 +1,114 @@
 # Backups and Recovery
 
-Home Assistant has **two independent recovery layers with very different blast radii**: a *full instance backup* (a tarball of the config directory and add-ons — restoring it restarts HA and reverts everything changed since it was taken) and *config-level rollback* (re-applying one stored automation/script/scene/dashboard/helper definition — no restart, one object). Picking the wrong layer is the common failure: a full restore used to undo a single automation edit also discards every unrelated change made in between.
+**Three different things get called a "backup" in Home Assistant work.** This file covers the first two, and only the first is a Home Assistant feature:
+
+1. A **full instance backup** — the archive Home Assistant creates at *Settings → System → Backups*, which is also the surface for restoring and deleting one.
+2. **Object rollback** — not an HA feature but a workflow: fetch an object's current definition *before* editing it, then write that definition back through the same config API to undo. One object, no restart.
+3. The **pre-edit file copy** a managed YAML write takes — a different mechanism entirely, covered in `references/yaml-only-integrations.md`.
+
+**Restoring a backup, deleting a backup, and upgrading Core are irreversible and require explicit user confirmation before you act — every time, including when a backup already exists.** A backup lowers recovery risk; it does not authorize the action.
 
 ## Table of Contents
-1. [Which Recovery Layer](#which-recovery-layer)
+1. [Which Recovery Path](#which-recovery-path)
 2. [When a Full Backup Earns Its Cost](#when-a-full-backup-earns-its-cost)
 3. [What a Full Backup Contains](#what-a-full-backup-contains)
 4. [Restoring: Consequences and Verification](#restoring-consequences-and-verification)
-5. [Why Deleting Backups Is Guarded](#why-deleting-backups-is-guarded)
+5. [Deleting Backups](#deleting-backups)
 6. [Common Pitfalls](#common-pitfalls)
 
 ---
 
-## Which Recovery Layer
+## Which Recovery Path
 
-| Situation | Layer |
-|-----------|-------|
-| One automation / script / scene / dashboard / helper edit went wrong | Config-level rollback — write the previous definition back. No restart. |
-| Several config objects edited in one session went wrong | Config-level rollback, one object at a time. Still no restart. |
-| A device, entity, or area was deleted from the registry | Full backup. Registry state (IDs, area/label assignments, and every reference other config held) is not recoverable from a config-level snapshot. |
-| An integration / config entry was removed | Full backup. Its entities and their recorded history went with it. |
-| An add-on update or removal broke something | Full backup, restored partially — the affected add-on only, where the restore flow allows it. |
-| A Core or OS upgrade broke the instance | Full backup restore. |
-| The instance no longer boots | Full backup restore through the Supervisor / onboarding restore flow. |
+| Situation | What to do |
+|-----------|------------|
+| One automation / script / scene / dashboard / helper edit went wrong | **Roll the object back** — write its previous definition back through the config API. No restart, nothing else touched. Fetching before writing is what makes this possible; see `references/safe-refactoring.md#universal-workflow`. |
+| Several objects were edited in one session | **Roll each object back**, one at a time. Still no restart. |
+| A device, entity, or area was deleted from the registry | **Restore a full backup.** Registry state — IDs, area/label assignments, and the references other config held to them — cannot be recovered by writing a definition back. |
+| An integration or config entry was removed | **Restore a full backup.** Its entities went with it. |
+| An App update or removal broke something | **Restore a full backup partially** — that App and its data only. |
+| A Core or Operating System upgrade broke the instance | **Restore a full backup.** |
+| The instance no longer boots | **Restore a full backup** through the Supervisor / onboarding restore flow. |
 
-Prefer the narrowest layer that can fix the problem. Config-level rollback is object-scoped, needs no restart, and cannot lose unrelated work.
+Prefer the narrowest path that can fix the fault. Object rollback is scoped to one object, needs no restart, and cannot lose unrelated work.
+
+**Partial restore is a narrower restore, not a rollback.** HA's partial restore (`hassio.restore_partial`) picks which parts of an existing backup to put back — Home Assistant settings, specific Apps, and folders. Including Home Assistant settings restarts HA. That is a different mechanism from writing one object's definition back through the config API, which restarts nothing.
 
 ## When a Full Backup Earns Its Cost
 
-The rule is reversibility, not risk-feel: **take a full backup before an operation you cannot undo by writing the old value back.**
+The test is reversibility, not how risky something feels: **back up before an operation you cannot undo by writing the old value back.**
 
-**Irreversible — back up first:**
+**Irreversible — take the backup first, and confirm the operation with the user:**
 - Deleting a device, entity, or area from the registry.
 - Removing an integration or config entry.
-- Removing an add-on, or a major add-on version jump.
-- Core / Operating System version upgrades.
+- Removing an App, or a major App version jump.
+- Core / Operating System upgrades.
 - Restoring a *different* backup — a restore is itself destructive of current state.
 - Bulk operations across many objects whose before-state was not captured.
+- Editing a Config-Entry integration whose fields have no post-setup API write path — see `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames`.
 
 **Reversible — a backup is usually redundant:**
-- Editing an automation / script / scene / dashboard / helper whose current definition was fetched first. Writing that fetched definition back *is* the undo.
+- Editing an automation / script / scene / dashboard / helper whose current definition was fetched first. Writing that definition back *is* the undo.
 - Renaming a friendly name, changing an icon, moving an entity between areas.
-- Toggling an entity or calling a service.
+- A service call whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity.
 
-Two things this rule depends on:
+**Neither list — treat as irreversible until you have checked:** a service call with no inverse (`vacuum.send_command`, any `*.press`, `notify.*`); anything that drives a physical mechanism (locks, covers, valves, garage doors); and anything whose effect leaves Home Assistant, since a sent notification or fired webhook cannot be recalled. "It's just a service call" is not a reversibility argument — the inverse depends on the service and the target.
 
-- **Timing is the whole point.** A backup taken *after* the destructive step captures the damage. It must precede the operation, not follow it.
-- **An existing backup schedule does not substitute.** On an instance with nightly automatic backups, the newest one can be almost a day stale — fine for reversible edits, not for an irreversible operation about to run now.
+Two things this test depends on:
+
+- **Timing is the whole point.** A backup taken *after* the destructive step captures the damage. It must precede the operation.
+- **An existing schedule does not substitute.** On an instance with nightly automatic backups, the newest one can be almost a day stale — fine for reversible edits, not for an irreversible operation about to run now.
 
 ## What a Full Backup Contains
 
-- The config directory: registries under `.storage`, YAML configuration, and the stored automations, scripts, scenes, dashboards, and helpers.
-- Add-ons and their data directories. Add-on selection is often partial — check what a given backup actually included before relying on it.
-- The recorder database is **optional and commonly excluded**, because it dominates the size. Excluded means long-term statistics and history do not come back on restore, even though every entity does.
-- Nothing outside the config directory. Files elsewhere on the host are not in the backup.
+Backup contents are **selected per backup**, so what a given archive holds is a property of that archive, not of Home Assistant:
 
-Backups contain credentials, tokens, and API keys in cleartext inside `.storage`. Treat the tarball as a secret: encrypt it, and do not copy it anywhere the user has not chosen.
+- **Home Assistant settings** — the config directory: `.storage` registries, YAML configuration, and the stored automations, scripts, scenes, dashboards, and helpers.
+- **The recorder database — included by default.** `include_database` defaults to true, so history and long-term statistics normally *are* in the backup and *do* come back on restore. The exceptions are a backup created with that option switched off, and a recorder pointed at an external database, which lives outside the backup entirely. Check the archive before telling a user their history will or won't return.
+- **Apps**, individually selectable, with their data directories.
+- **Folders**, individually selectable: `share`, `addons/local`, `ssl`, `media`.
+
+Nothing else on the host is included, and a restore overwrites only the parts a given backup actually contains.
+
+**Encryption and secrets.** Backups are password-protected by default, and restoring one requires its encryption key — the key issued in the backup emergency kit when HA sets up encrypted backups. **An archive without its key is not a recovery point**, so verify the user has the emergency kit before treating a backup as a fallback. A backup downloaded through the UI is decrypted on the way out, and that copy carries `.storage` in cleartext — credentials, long-lived tokens, API keys. Protect the archive and the emergency kit as separate secrets, and never move either anywhere the user has not chosen.
 
 ## Restoring: Consequences and Verification
 
-- A **full restore reverts everything** changed since the backup was taken, then restarts HA. Name the changes that will be lost and confirm before restoring — the user often has unrelated work in that window.
-- A **partial restore** (config only, or one add-on) narrows the blast radius. Prefer it whenever the fault is localised.
-- A **config-level rollback** re-applies one definition through the normal write path; the object reloads and no restart happens.
+- **Confirm before restoring.** Naming which changes will be lost is part of the ask.
+- A **full restore** reverts every included part to its state at backup time and restarts HA. Unrelated work done in that window is gone.
+- A **partial restore** narrows the blast radius; prefer it whenever the fault is localised. Including Home Assistant settings still restarts HA.
+- An **object rollback** through the config API restarts nothing and touches one object.
 
 After any restore, verify rather than assume:
 - Entities are available, not `unavailable` — a restored config entry whose credentials expired comes back broken.
 - The error log is clean of startup failures.
-- Cloud-backed integrations may need re-authentication; a restore replays a token that has since been rotated.
+- Cloud-backed integrations may need re-authentication; a restore replays a token that may have been rotated since.
 - Objects that were disabled when the backup was taken come back disabled.
 
-## Why Deleting Backups Is Guarded
+## Deleting Backups
 
-Deleting backups is guarded because the point of a backup is to survive a mistake made by whoever is currently editing the instance — including an automated agent. Three properties follow:
+Be precise about what Home Assistant protects here, because it is less than it looks:
 
-- **The newest remaining backup is never a valid delete target.** It is the only guaranteed rollback for whatever just happened.
-- **Scheduled / automatic backups belong to a retention policy.** Deleting them ad hoc silently breaks the guarantee the schedule was configured to provide.
-- **A minimum-age floor protects the recent ones.** Breakage is usually noticed hours after the change that caused it, so a young backup may be the only snapshot predating the change under investigation.
+- The **retention cleanup** that enforces a backup schedule will not delete the last remaining backup for a backup location.
+- A **direct delete of one specific backup** — the operation performed when a user asks for a particular backup to be removed — has **no such guard**, and there is no minimum-age protection anywhere. Delete the only recovery point and Home Assistant will carry it out.
 
-Storage pressure is the legitimate reason to delete. When it applies: delete oldest-first, keep the newest and the most recent known-good, and confirm the specific target with the user.
+So on this operation the caution has to come from whoever is driving, not from the platform:
+
+- **Confirm the specific backup with the user before deleting it** — name which one and how old it is.
+- **Leave at least one recent, usable recovery point.** Usable includes having its encryption key available.
+- **Delete oldest first** when clearing several.
+
+Storage pressure is not the only legitimate reason to delete. A credential compromise can make the archive itself the liability; a privacy or retention requirement can mandate removal; and a user can simply ask. None of those removes the confirmation step or the keep-one-recovery-point guidance.
 
 ## Common Pitfalls
 
-- **Backing up after the destructive step.** The snapshot now contains the damage.
-- **Using a full restore to undo one config edit.** Discards every unrelated change made since.
-- **Expecting history back.** The recorder database is usually excluded; entities return, their statistics do not.
-- **Deleting the newest backup to free space.** Removes the only recovery point for the change being investigated.
+- **Backing up after the destructive step.** The archive now contains the damage.
+- **Using a full restore to undo one config edit.** It reverts every unrelated change since, and restarts HA.
+- **Assuming a direct backup delete is guarded.** It isn't — only the scheduled retention cleanup keeps a last backup.
+- **Treating an archive without its encryption key as a recovery point.** It cannot be restored.
+- **Treating a UI-downloaded backup as an ordinary file.** It is decrypted, and it holds cleartext credentials and tokens.
+- **Claiming history will or won't come back without checking.** The recorder database is included by default, but per-backup selection and external databases both change the answer.
+- **Calling a service "reversible" without naming its inverse.**
 - **Treating a backup as a substitute for fetching the current definition before an edit.** Fetching is cheaper, object-scoped, and needs no restart to undo.
-- **Keeping backups only on the instance they back up.** One disk or host failure takes the instance and its recovery points together. Copy them off-box.
+- **Keeping backups only on the instance they back up.** One disk or host failure takes the instance and its recovery points together.
+- **Acting on an irreversible operation because a backup exists.** The backup is the safety net, not the authorization — the user's confirmation is.

--- a/skills/home-assistant-best-practices/references/backups.md
+++ b/skills/home-assistant-best-practices/references/backups.md
@@ -1,0 +1,89 @@
+# Backups and Recovery
+
+Home Assistant has **two independent recovery layers with very different blast radii**: a *full instance backup* (a tarball of the config directory and add-ons — restoring it restarts HA and reverts everything changed since it was taken) and *config-level rollback* (re-applying one stored automation/script/scene/dashboard/helper definition — no restart, one object). Picking the wrong layer is the common failure: a full restore used to undo a single automation edit also discards every unrelated change made in between.
+
+## Table of Contents
+1. [Which Recovery Layer](#which-recovery-layer)
+2. [When a Full Backup Earns Its Cost](#when-a-full-backup-earns-its-cost)
+3. [What a Full Backup Contains](#what-a-full-backup-contains)
+4. [Restoring: Consequences and Verification](#restoring-consequences-and-verification)
+5. [Why Deleting Backups Is Guarded](#why-deleting-backups-is-guarded)
+6. [Common Pitfalls](#common-pitfalls)
+
+---
+
+## Which Recovery Layer
+
+| Situation | Layer |
+|-----------|-------|
+| One automation / script / scene / dashboard / helper edit went wrong | Config-level rollback — write the previous definition back. No restart. |
+| Several config objects edited in one session went wrong | Config-level rollback, one object at a time. Still no restart. |
+| A device, entity, or area was deleted from the registry | Full backup. Registry state (IDs, area/label assignments, and every reference other config held) is not recoverable from a config-level snapshot. |
+| An integration / config entry was removed | Full backup. Its entities and their recorded history went with it. |
+| An add-on update or removal broke something | Full backup, restored partially — the affected add-on only, where the restore flow allows it. |
+| A Core or OS upgrade broke the instance | Full backup restore. |
+| The instance no longer boots | Full backup restore through the Supervisor / onboarding restore flow. |
+
+Prefer the narrowest layer that can fix the problem. Config-level rollback is object-scoped, needs no restart, and cannot lose unrelated work.
+
+## When a Full Backup Earns Its Cost
+
+The rule is reversibility, not risk-feel: **take a full backup before an operation you cannot undo by writing the old value back.**
+
+**Irreversible — back up first:**
+- Deleting a device, entity, or area from the registry.
+- Removing an integration or config entry.
+- Removing an add-on, or a major add-on version jump.
+- Core / Operating System version upgrades.
+- Restoring a *different* backup — a restore is itself destructive of current state.
+- Bulk operations across many objects whose before-state was not captured.
+
+**Reversible — a backup is usually redundant:**
+- Editing an automation / script / scene / dashboard / helper whose current definition was fetched first. Writing that fetched definition back *is* the undo.
+- Renaming a friendly name, changing an icon, moving an entity between areas.
+- Toggling an entity or calling a service.
+
+Two things this rule depends on:
+
+- **Timing is the whole point.** A backup taken *after* the destructive step captures the damage. It must precede the operation, not follow it.
+- **An existing backup schedule does not substitute.** On an instance with nightly automatic backups, the newest one can be almost a day stale — fine for reversible edits, not for an irreversible operation about to run now.
+
+## What a Full Backup Contains
+
+- The config directory: registries under `.storage`, YAML configuration, and the stored automations, scripts, scenes, dashboards, and helpers.
+- Add-ons and their data directories. Add-on selection is often partial — check what a given backup actually included before relying on it.
+- The recorder database is **optional and commonly excluded**, because it dominates the size. Excluded means long-term statistics and history do not come back on restore, even though every entity does.
+- Nothing outside the config directory. Files elsewhere on the host are not in the backup.
+
+Backups contain credentials, tokens, and API keys in cleartext inside `.storage`. Treat the tarball as a secret: encrypt it, and do not copy it anywhere the user has not chosen.
+
+## Restoring: Consequences and Verification
+
+- A **full restore reverts everything** changed since the backup was taken, then restarts HA. Name the changes that will be lost and confirm before restoring — the user often has unrelated work in that window.
+- A **partial restore** (config only, or one add-on) narrows the blast radius. Prefer it whenever the fault is localised.
+- A **config-level rollback** re-applies one definition through the normal write path; the object reloads and no restart happens.
+
+After any restore, verify rather than assume:
+- Entities are available, not `unavailable` — a restored config entry whose credentials expired comes back broken.
+- The error log is clean of startup failures.
+- Cloud-backed integrations may need re-authentication; a restore replays a token that has since been rotated.
+- Objects that were disabled when the backup was taken come back disabled.
+
+## Why Deleting Backups Is Guarded
+
+Deleting backups is guarded because the point of a backup is to survive a mistake made by whoever is currently editing the instance — including an automated agent. Three properties follow:
+
+- **The newest remaining backup is never a valid delete target.** It is the only guaranteed rollback for whatever just happened.
+- **Scheduled / automatic backups belong to a retention policy.** Deleting them ad hoc silently breaks the guarantee the schedule was configured to provide.
+- **A minimum-age floor protects the recent ones.** Breakage is usually noticed hours after the change that caused it, so a young backup may be the only snapshot predating the change under investigation.
+
+Storage pressure is the legitimate reason to delete. When it applies: delete oldest-first, keep the newest and the most recent known-good, and confirm the specific target with the user.
+
+## Common Pitfalls
+
+- **Backing up after the destructive step.** The snapshot now contains the damage.
+- **Using a full restore to undo one config edit.** Discards every unrelated change made since.
+- **Expecting history back.** The recorder database is usually excluded; entities return, their statistics do not.
+- **Deleting the newest backup to free space.** Removes the only recovery point for the change being investigated.
+- **Treating a backup as a substitute for fetching the current definition before an edit.** Fetching is cheaper, object-scoped, and needs no restart to undo.
+- **Keeping backups only on the instance they back up.** One disk or host failure takes the instance and its recovery points together. Copy them off-box.

--- a/skills/home-assistant-best-practices/references/backups.md
+++ b/skills/home-assistant-best-practices/references/backups.md
@@ -6,7 +6,13 @@
 2. **Object rollback** — not an HA feature but a workflow: fetch an object's current definition *before* editing it, then write that definition back through the same config API to undo. One object, no restart.
 3. The **pre-edit file copy** a managed YAML write takes — a different mechanism entirely, covered in `references/yaml-only-integrations.md`.
 
-**Restoring a backup, deleting a backup, and upgrading Core are irreversible and require explicit user confirmation before you act — every time, including when a backup already exists.** A backup lowers recovery risk; it does not authorize the action.
+**Three operations need explicit user confirmation before you act — every time, including when a backup already exists.** They differ in kind, so say which one applies:
+
+- **Restoring a backup** — *irreversible*: it discards every change made since that archive and restarts HA. The only way back is another backup taken before the restore.
+- **Deleting a backup** — *irreversible*: the archive is gone, and with it any recovery point it was the last copy of.
+- **Upgrading Core or the OS** — *high-impact rather than strictly irreversible*: it can break integrations and custom components, and the recovery path is restoring the pre-upgrade backup, which is why one has to exist first.
+
+A backup lowers recovery risk; it does not authorize the action.
 
 ## Table of Contents
 1. [Which Recovery Path](#which-recovery-path)
@@ -26,13 +32,15 @@
 | Several objects were edited in one session | **Roll each object back**, one at a time. Still no restart. |
 | A device, entity, or area was deleted from the registry | **Restore a full backup.** Registry state — IDs, area/label assignments, and the references other config held to them — cannot be recovered by writing a definition back. |
 | An integration or config entry was removed | **Restore a full backup.** Its entities went with it. |
-| An App update or removal broke something | **Restore a full backup partially** — that App and its data only. |
+| An App update or removal broke something | **Restore a full backup partially** — that App and its data only. Supervisor installs (OS/Supervised) only; elsewhere it is a full restore. |
 | A Core or Operating System upgrade broke the instance | **Restore a full backup.** |
 | The instance no longer boots | **Restore a full backup** through the Supervisor / onboarding restore flow. |
 
 Prefer the narrowest path that can fix the fault. Object rollback is scoped to one object, needs no restart, and cannot lose unrelated work.
 
 **Partial restore is a narrower restore, not a rollback.** HA's partial restore (`hassio.restore_partial`) picks which parts of an existing backup to put back — Home Assistant settings, specific Apps, and folders. Including Home Assistant settings restarts HA. That is a different mechanism from writing one object's definition back through the config API, which restarts nothing.
+
+**Partial restore needs a Supervisor**, so it exists on Home Assistant OS and Supervised only. On Container and Core installs the `hassio` integration is not loaded, there is no partial restore, and the recovery options are object rollback or a full restore through whatever backup mechanism that install uses. Check which install you are on before offering a partial restore as a step.
 
 ## When a Full Backup Earns Its Cost
 
@@ -52,7 +60,13 @@ The test is reversibility, not how risky something feels: **back up before an op
 - Renaming a friendly name, changing an icon, moving an entity between areas.
 - A service call whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity.
 
-**Neither list — treat as irreversible until you have checked:** a service call with no inverse (`vacuum.send_command`, any `*.press`, `notify.*`); anything that drives a physical mechanism (locks, covers, valves, garage doors); and anything whose effect leaves Home Assistant, since a sent notification or fired webhook cannot be recalled. "It's just a service call" is not a reversibility argument — the inverse depends on the service and the target.
+**Neither list — treat as irreversible until you have checked.** The exact-inverse test is the rule; these are the cases where passing it still is not enough:
+
+- **No inverse exists.** `vacuum.send_command`, any `*.press`, `notify.*` — nothing to call to undo them.
+- **The inverse exists but does not undo the consequence.** `lock.unlock` ↔ `lock.lock` and `cover.open_cover` ↔ `cover.close_cover` are exact inverses, yet the door was unlocked and the cover was open in between. Re-locking restores the state, not the exposure. Confirm these with the user first even though they are mechanically reversible.
+- **The effect has already left Home Assistant.** A sent notification or a fired webhook cannot be recalled, whatever you call next.
+
+"It's just a service call" is not a reversibility argument — the inverse depends on the service and the target, and a reversible state change is not always a reversible event.
 
 Two things this test depends on:
 
@@ -64,7 +78,7 @@ Two things this test depends on:
 Backup contents are **selected per backup**, so what a given archive holds is a property of that archive, not of Home Assistant:
 
 - **Home Assistant settings** — the config directory: `.storage` registries, YAML configuration, and the stored automations, scripts, scenes, dashboards, and helpers.
-- **The recorder database — included by default.** `include_database` defaults to true, so history and long-term statistics normally *are* in the backup and *do* come back on restore. The exceptions are a backup created with that option switched off, and a recorder pointed at an external database, which lives outside the backup entirely. Check the archive before telling a user their history will or won't return.
+- **The recorder database — usually included, but confirm rather than assume.** Home Assistant Core's own backup config defaults `include_database` to true (2026.8.1), so history and long-term statistics normally *are* in the archive and *do* come back. Three things change that answer: the option can be switched off for an individual backup; on Supervised/OS the Supervisor API takes `homeassistant_exclude_database` per backup and the `backups_exclude_database` setting can make exclusion the *default* for every future one; and a recorder pointed at an external database lives outside the archive entirely. Check the archive and the install before telling a user their history will or won't return.
 - **Apps**, individually selectable, with their data directories.
 - **Folders**, individually selectable: `share`, `addons/local`, `ssl`, `media`.
 
@@ -108,7 +122,7 @@ Storage pressure is not the only legitimate reason to delete. A credential compr
 - **Treating an archive without its encryption key as a recovery point.** It cannot be restored.
 - **Treating a UI-downloaded backup as an ordinary file.** It is decrypted, and it holds cleartext credentials and tokens.
 - **Claiming history will or won't come back without checking.** The recorder database is included by default, but per-backup selection and external databases both change the answer.
-- **Calling a service "reversible" without naming its inverse.**
+- **Calling a service "reversible" without naming its inverse** — or treating a mechanical inverse as undoing the consequence, when the door was still unlocked in between.
 - **Treating a backup as a substitute for fetching the current definition before an edit.** Fetching is cheaper, object-scoped, and needs no restart to undo.
 - **Keeping backups only on the instance they back up.** One disk or host failure takes the instance and its recovery points together.
 - **Acting on an irreversible operation because a backup exists.** The backup is the safety net, not the authorization — the user's confirmation is.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -205,7 +205,7 @@ Iterate the returned entries and check `data` and `options` fields for the old e
 
 For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
 
-For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename.
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename. This is the one operation in this guide that a fetch-before-write rollback cannot undo, so treat the rename as irreversible and take a full backup first — see `references/backups.md#when-a-full-backup-earns-its-cost`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds `references/backups.md` — the backup/recovery knowledge that `home-assistant-best-practices` currently has no landing spot for.

**Why here, and why now.** ha-mcp's `enable_lite_docstrings` beta feature trims heavy tool descriptions and defers the detail to this skill. In review of homeassistant-ai/ha-mcp#2153 the maintainer established that the two largest remaining descriptions outside its map — backup management and issue reporting — point at a skill pack that covers neither, so a *compliant* agent that follows the trimmed pointer exactly as instructed reads a guide about automations and dashboards and comes back with nothing. This is the backup half of that fix; ha-mcp then bumps its submodule pin.

**Framed in HA concepts, not tool names**, per CONTRIBUTING. The durable knowledge here isn't a call signature — it's which of HA's two recovery layers fits a situation, and that the choice hinges on reversibility:

- **Full instance backup vs config-level rollback**, with a situation table. A full restore reverts every unrelated change made since the backup and restarts HA, which makes it the wrong instrument for one bad automation edit — the pitfall the first anti-pattern row names.
- **When a backup earns its cost:** before operations that cannot be undone by writing the old value back (registry deletions, integration/config-entry removal, add-on removal, Core/OS upgrades, restoring a *different* backup). Two things make this operational rather than obvious: timing is load-bearing — a backup taken after the destructive step captures the damage — and an existing nightly schedule does not substitute, because its newest snapshot can be almost a day stale.
- **What a full backup contains.** The recorder database is commonly excluded, so entities come back on restore but their long-term statistics do not. `.storage` holds cleartext credentials and tokens, which makes the tarball a secret.
- **Restore consequences and verification.** Prefer the narrowest restore that fixes the fault, and check the things that actually catch a bad restore: entity availability, startup errors, cloud integrations whose tokens rotated since the backup, objects that were disabled at backup time.
- **Why deleting backups is guarded**, as reasoning rather than a flag list — the newest remaining backup is the only guaranteed rollback for whatever just happened, scheduled backups belong to a retention policy, and a minimum-age floor exists because breakage is usually noticed hours after the change that caused it.

Two `Critical Anti-Patterns` rows cover the two failures this reference exists to prevent: a full restore used to undo one config edit, and an irreversible registry operation run with no preceding backup.

### Three deliberate omissions, in case you'd rather I change them

**Issue reporting is not here.** ha-mcp#2153 also defers `ha_report_issue` to this skill, so the obvious move would be a second reference file. I didn't write one: it is ha-mcp product meta — inseparable from that server's own tool names and report templates — so it would break the *"don't couple skills to specific tool names"* principle and wouldn't apply to an arbitrary HA installation. That pointer is being fixed on the ha-mcp side instead. Say the word if you'd rather it live here anyway.

**No frontmatter changes.** `description` is at **1016 of the 1024-character limit**, so there is no room for backup trigger/symptom bullets without cutting existing ones. Routing for this reference therefore comes from the Reference Files table — which is what the ha-mcp pointer lands on, so that path works — but a question asked cold ("should I back up first?") won't match the skill on description alone. Happy to propose a trim if you want the triggers in.

**No eval added.** `evals/evals.json` isn't wired into CI and I can't run an agent eval here, so I left it alone rather than commit an untested entry.

## Checklist

- [ ] Tested with real scenarios (if changing skill content)
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)

**On the unticked box:** no agent test. I verified the mechanics — `python -m skills_ref.cli validate` passes, and all six section anchors resolve through ha-mcp's own `skill_loader.resolve_skill_files` slugifier (they're cited from the SKILL.md table, so a slug mismatch would silently return nothing). What I have *not* done is put an agent in front of this reference to confirm it changes the backup decision it's meant to change. That's the risk worth a maintainer's eye.

`metadata.version` left at 16 — CI owns that field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Home Assistant backup and recovery guidance.
  * Documented full-instance backups, configuration rollback, restore consequences, credential handling, verification steps, and safeguards for deleting backups.
  * Clarified backup requirements and recovery-path selection, including database contents and encryption key considerations.
  * Clarified that certain configuration-entry renames are irreversible and require a full backup.
  * Updated best-practice activation guidance for backup deletion, restoration, and Core or OS upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->