### PR TITLE
Fix template defaults, sweep 2026.8, make cross-references link-checkable

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -11,8 +11,9 @@ code_review:
           err toward over-triggering rather than under-triggering; good descriptions
           include explicit TRIGGER WHEN and SYMPTOMS sections listing observable agent
           behaviors that signal the skill is needed
-        - `metadata.version`: monotonically incrementing integer managed by CI; new
-          skills set it to `0` as a placeholder — do not edit manually
+        - `metadata.version`: monotonically incrementing integer, written as a quoted
+          string per the spec; managed by CI; new skills set it to `"0"` as a
+          placeholder — do not edit manually
 
         ## Structure
         - SKILL.md must stay under 500 lines
@@ -21,11 +22,15 @@ code_review:
         - Use forward slashes in all file paths
 
         ## Content quality
-        - Include only domain-specific knowledge agents lack; omit general programming advice
+        - Keep what is Home Assistant-specific; cut general programming advice. The test is
+          whether the content is HA-specific, not whether a model already knows it — these
+          skills run on agents from frontier models to small local ones. Keep anywhere HA
+          diverges from what the general syntax implies (e.g. `state_attr` returns `None`,
+          not an undefined, so `| default(x)` does not catch it).
         - Provide patterns and quick-reference tables, not tutorials
         - One term per concept throughout (consistent terminology)
         - Explain the *why* behind instructions rather than issuing bare MUST/NEVER commands
-        - If bundled scripts exist, the skill should tell Claude when and how to use them
+        - If bundled scripts exist, the skill should tell the agent when and how to use them
 
         ## Common pitfalls
         - Skills should not reference specific MCP tool names (e.g. `ha_rename_entity`,

--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -104,10 +104,10 @@ jobs:
               /^---/{fd++; print; next}
               fd==1 && /^metadata:/{m=1; print; next}
               fd==1 && m && /^[[:space:]]+version:/{
-                if (/version:[[:space:]]*"/)
-                  sub(/"[^"]*"/, new_ver)    # quoted string — strip quotes and write bare integer
-                else
-                  sub(/[0-9]+/, new_ver)     # unquoted integer
+                # The spec requires metadata values to be strings, so the integer
+                # is written quoted. Handles both the quoted steady state and any
+                # remaining unquoted value.
+                sub(/version:.*/, "version: \"" new_ver "\"")
                 m=0
               }
               {print}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,45 @@
+name: Links
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      # SKILL.md links to references/examples.yaml; without this a rename of a
+      # linked .yaml touches no .md and the broken link merges unchecked.
+      - '**/*.yaml'
+  schedule:
+    # External links rot on their own schedule, not ours — check weekly.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  internal:
+    # Local file paths and #anchors only. No network, so it is deterministic
+    # and safe to block a PR on.
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check internal links and anchors
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --include-fragments --no-progress './**/*.md'
+          fail: true
+
+  external:
+    # Network-dependent: a dead upstream or a rate limit would fail unrelated
+    # PRs, so this runs on a schedule instead of in the merge path.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check external links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --max-retries 3 './**/*.md'
+          fail: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -23,6 +23,10 @@ env:
   # into RUNNER_TEMP — unpacking it into the workspace would make lychee scan
   # its own documentation.
   LYCHEE_VERSION: v0.24.2
+  # Digest pinned here, not read from the release's own .sha256: a retag could
+  # replace the archive and its checksum together, so verifying one against the
+  # other proves nothing (CWE-494). Update both lines when bumping the version.
+  LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
 
 jobs:
   internal:
@@ -42,8 +46,8 @@ jobs:
           dest="${RUNNER_TEMP}/lychee"
           mkdir -p "$dest"
           gh release download "lychee-${LYCHEE_VERSION}" --repo lycheeverse/lychee \
-            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
-          (cd "$dest" && sha256sum -c "$asset.sha256")
+            --pattern "$asset" --dir "$dest"
+          echo "${LYCHEE_SHA256}  ${dest}/${asset}" | sha256sum -c -
           tar xzf "$dest/$asset" -C "$dest" --strip-components=1
           echo "$dest" >> "$GITHUB_PATH"
           "$dest/lychee" --version
@@ -68,8 +72,8 @@ jobs:
           dest="${RUNNER_TEMP}/lychee"
           mkdir -p "$dest"
           gh release download "lychee-${LYCHEE_VERSION}" --repo lycheeverse/lychee \
-            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
-          (cd "$dest" && sha256sum -c "$asset.sha256")
+            --pattern "$asset" --dir "$dest"
+          echo "${LYCHEE_SHA256}  ${dest}/${asset}" | sha256sum -c -
           tar xzf "$dest/$asset" -C "$dest" --strip-components=1
           echo "$dest" >> "$GITHUB_PATH"
           "$dest/lychee" --version

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - '**/*.md'
       # SKILL.md links to references/examples.yaml; without this a rename of a
-      # linked .yaml touches no .md and the broken link merges unchecked.
+      # linked .yaml touches no markdown, the workflow never runs, and the
+      # broken link merges unchecked.
       - '**/*.yaml'
   schedule:
     # External links rot on their own schedule, not ours — check weekly.
@@ -15,20 +16,40 @@ on:
 permissions:
   contents: read
 
+env:
+  # This repo restricts Actions to GitHub-owned and verified creators, so lychee
+  # is installed as a checksum-verified release binary rather than via its
+  # action. The archive ships its own README.md and docs/, so it is unpacked
+  # into RUNNER_TEMP — unpacking it into the workspace would make lychee scan
+  # its own documentation.
+  LYCHEE_VERSION: v0.24.2
+
 jobs:
   internal:
-    # Local file paths and #anchors only. No network, so it is deterministic
-    # and safe to block a PR on.
+    # Local file paths and #anchors only. No network, so it is deterministic and
+    # safe to block a merge on.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install lychee
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          asset="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          dest="${RUNNER_TEMP}/lychee"
+          mkdir -p "$dest"
+          gh release download "lychee-${LYCHEE_VERSION}" --repo lycheeverse/lychee \
+            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
+          (cd "$dest" && sha256sum -c "$asset.sha256")
+          tar xzf "$dest/$asset" -C "$dest" --strip-components=1
+          echo "$dest" >> "$GITHUB_PATH"
+          "$dest/lychee" --version
+
       - name: Check internal links and anchors
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --offline --include-fragments --no-progress './**/*.md'
-          fail: true
+        run: lychee --offline --include-fragments --no-progress './**/*.md'
 
   external:
     # Network-dependent: a dead upstream or a rate limit would fail unrelated
@@ -38,8 +59,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install lychee
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          asset="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          dest="${RUNNER_TEMP}/lychee"
+          mkdir -p "$dest"
+          gh release download "lychee-${LYCHEE_VERSION}" --repo lycheeverse/lychee \
+            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
+          (cd "$dest" && sha256sum -c "$asset.sha256")
+          tar xzf "$dest/$asset" -C "$dest" --strip-components=1
+          echo "$dest" >> "$GITHUB_PATH"
+          "$dest/lychee" --version
+
       - name: Check external links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress --max-retries 3 './**/*.md'
-          fail: true
+        run: lychee --no-progress --max-retries 3 './**/*.md'

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -67,12 +67,24 @@ jobs:
         # version) that strict clients refuse to parse. Scoped to skills/ and
         # left non-strict on purpose: repo-wide, agnix also emits prose-style
         # heuristics about CLAUDE.md that should not gate a merge.
+        #
+        # Installed as a checksum-verified release binary because this repo
+        # restricts Actions to GitHub-owned and verified creators.
         if: steps.changes.outputs.skills_changed == 'true'
-        uses: agent-sh/agnix@v0.49.0
-        with:
-          path: skills/
-          target: claude-code
-          version: '0.49.0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AGNIX_VERSION: v0.49.0
+        run: |
+          set -euo pipefail
+          asset="agnix-x86_64-unknown-linux-gnu.tar.gz"
+          dest="${RUNNER_TEMP}/agnix"
+          mkdir -p "$dest"
+          gh release download "$AGNIX_VERSION" --repo agent-sh/agnix \
+            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
+          (cd "$dest" && sha256sum -c "$asset.sha256")
+          tar xzf "$dest/$asset" -C "$dest"
+          "$dest/agnix" --version
+          "$dest/agnix" skills/ --target claude-code
 
       - name: Enforce version not manually changed
         if: steps.changes.outputs.skills_changed == 'true' && github.event_name == 'pull_request'

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -74,14 +74,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           AGNIX_VERSION: v0.49.0
+          # Pinned digest — see the note in links.yml on why the release's own
+          # .sha256 is not a sufficient integrity check.
+          AGNIX_SHA256: e3bb9e3661025d54cc5d5835c429548d2a6e0626135363c41c044822f861bcbd
         run: |
           set -euo pipefail
           asset="agnix-x86_64-unknown-linux-gnu.tar.gz"
           dest="${RUNNER_TEMP}/agnix"
           mkdir -p "$dest"
           gh release download "$AGNIX_VERSION" --repo agent-sh/agnix \
-            --pattern "$asset" --pattern "$asset.sha256" --dir "$dest"
-          (cd "$dest" && sha256sum -c "$asset.sha256")
+            --pattern "$asset" --dir "$dest"
+          echo "${AGNIX_SHA256}  ${dest}/${asset}" | sha256sum -c -
           tar xzf "$dest/$asset" -C "$dest"
           "$dest/agnix" --version
           "$dest/agnix" skills/ --target claude-code

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -60,6 +60,20 @@ jobs:
           done
           exit $exit_code
 
+      - name: Lint skills with agnix
+        # Second opinion on spec conformance. skills-ref declares
+        # `metadata: dict[str, str]` as a Python annotation with no runtime
+        # check, so it passes type violations (e.g. an unquoted integer
+        # version) that strict clients refuse to parse. Scoped to skills/ and
+        # left non-strict on purpose: repo-wide, agnix also emits prose-style
+        # heuristics about CLAUDE.md that should not gate a merge.
+        if: steps.changes.outputs.skills_changed == 'true'
+        uses: agent-sh/agnix@v0.49.0
+        with:
+          path: skills/
+          target: claude-code
+          version: '0.49.0'
+
       - name: Enforce version not manually changed
         if: steps.changes.outputs.skills_changed == 'true' && github.event_name == 'pull_request'
         env:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,13 @@
+# Fetch-on-demand URL templates: the placeholder is substituted by the agent at
+# runtime, so the literal URL is not resolvable.
+.*\{[a-z_]+\}.*
+.*<[a-z_]+>.*
+
+# Stand-in repo URL in the blueprint `source_url` example.
+https://github\.com/you/.*
+
+# Illustrative endpoints inside YAML examples, not real services.
+https?://([a-z]+\.)?example\.com.*
+
+# Local-network instance addresses; unreachable from CI by design.
+https?://homeassistant\.local.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Repo Layout
+
+One skill lives under `skills/<name>/`: `SKILL.md` plus `references/` (one level deep only),
+`evals/evals.json`, and optional `scripts/`/`assets/`. `docs/plans/` is gitignored
+scratch space.
+
+**SKILL.md is in context on every trigger; `references/` load only when read.** That is why
+SKILL.md body size is capped and why domain-niche content belongs in a reference file behind
+a single routing row, not in the always-loaded table.
+
 ## Skill Format
 
 Every skill is a `SKILL.md` file with YAML frontmatter:
@@ -15,11 +25,17 @@ description: >
 ```
 
 Full authoring constraints: `CONTRIBUTING.md`. The one CI cannot catch:
-- `metadata.version` must be `0` on new skills — do not edit manually; CI assigns the real version on merge
+- `metadata.version` must be `"0"` on new skills — do not edit manually; CI assigns the real version on merge
+- `description` is capped at 1024 chars and runs close to it — measure the parsed length before adding trigger/symptom bullets
 
 ## Skill Authoring Principles
 
-- **Context window conservation** — only include domain-specific knowledge that agents lack; omit general programming advice
+The wording of these content-quality principles is mirrored in `CONTRIBUTING.md`
+(contributors) and `.gemini/config.yaml` (automated PR review); each file also carries
+guidance the others omit. When you change a shared principle, change all three — they have
+drifted before.
+
+- **Context window conservation** — keep what is HA-specific, cut general programming advice; the test is the content itself, not whether a given model already knows it (skills run on frontier and small local models alike)
 - **Conciseness** — provide patterns and quick-reference tables, not tutorials
 - **Consistent terminology** — one term per concept throughout a skill
 - **Symptom-based triggering** — the `description` frontmatter should describe observable agent behaviors that signal the skill is needed
@@ -30,11 +46,20 @@ Full authoring constraints: `CONTRIBUTING.md`. The one CI cannot catch:
 To validate locally:
 
 ```bash
-uvx skills-ref validate skills/<skill-name>
+uvx --from skills-ref agentskills validate skills/<skill-name>
 ```
+
+`.github/workflows/links.yml` runs lychee over the repo's markdown, dot-directories
+excluded: local file links and their `#anchors` (`--offline --include-fragments`) on PRs
+that touch `.md`/`.yaml`, and external URLs weekly. It cannot see references written as
+inline code, and nothing checks that every reference file is still routed from SKILL.md —
+that stays a review item.
 
 ## Reviewing Skill PRs
 
 - Judge prose as agent-consumed context, not human docs — the Skill Authoring Principles above are the review bar (e.g. an operator→result lookup table beats narrative bullets, because agents land here holding one case to resolve)
-- Skills make version-pinned claims about HA behavior — verify against source at the release tag: `gh api repos/home-assistant/core/contents/<path>?ref=2026.7.4 --jq .content | base64 -d`
+- Skills make version-pinned claims about HA behavior — verify against source at the current tag (`gh api repos/home-assistant/core/releases --jq '.[0].tag_name'`): `gh api repos/home-assistant/core/contents/<path>?ref=<tag> --jq .content | base64 -d`
+- Purpose-specific trigger/condition keys aren't enumerable from core source — list them from the docs repo: `gh api "repos/home-assistant/home-assistant.io/contents/source/_triggers?ref=current" --jq '.[].name'` (also `_conditions`, `_actions`)
+- UI renames, terminology, and default changes appear only in release blog posts, not core source: `source/_posts/<date>-release-<version>.markdown` in the docs repo (e.g. `2026-08-05-release-20268.markdown`). Use `gh api` — plain `curl` is sandboxed here and returns empty
+- **The blog says *what* changed, not *which version* it landed in.** Its prose often implies a feature pre-existed ("X now has conditions to match its triggers") when the whole component is new. Date a feature by fetching its path at the *previous* tag — a 404 at the previous tag that exists at the current one means the whole thing is new
 - Community PRs come from forks: base-repo `?ref=<pr-branch>` 404s; get the fork with `gh pr view <pr> --json headRepository` and fetch files from there

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,19 +18,22 @@ skills/
 ### SKILL.md requirements
 
 - **YAML frontmatter** with `name` (letters, numbers, hyphens only; 64 chars max) and `description` (1024 chars max).
-- **`metadata.version`** a monotonically incrementing integer (e.g. `1`). Set to `0` when creating a new skill — CI assigns the real version automatically on merge. Do not edit this field manually.
+- **`metadata.version`** a monotonically incrementing integer written as a string (e.g. `"1"`) — the spec requires metadata values to be strings. Set to `0` when creating a new skill — CI assigns the real version automatically on merge. Do not edit this field manually.
 - **`description`** in third person. Describe what the skill does and when to use it. Include keywords that help agents match tasks. Don't summarize the skill's workflow.
 - **Body** under 500 lines. Split into reference files if approaching this limit.
 - **Reference files** one level deep from SKILL.md—no nested references.
+- **Cross-reference them with markdown links**, not inline code — CI validates both the path and the `#anchor`. Links resolve relative to the containing file, so inside `references/` a sibling is `x.md`, not `references/x.md`.
 - **Forward slashes** in all file paths.
 
 See Anthropic's [skill authoring best practices](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/best-practices) for additional guidance.
 
 ## Guiding Principles
 
-**The context window is a public good.** Only add what the agent doesn't already know. Challenge every paragraph: does its token cost justify its value?
+**The context window is a public good.** Every line is loaded on every invocation, by every agent. Challenge each paragraph: does its token cost justify its value?
 
-**Concise over verbose.** Claude is smart. Provide domain-specific knowledge and patterns, not general explanations.
+**Domain-specific, not general.** The test is whether the knowledge is Home Assistant-specific — *not* whether a model already knows it. These skills install into agents ranging from frontier models to small local ones, so "the model knows this" is not something a reviewer can evaluate, and it is the wrong question anyway. Keep HA behaviour, version-pinned changes, and anywhere HA diverges from what the general syntax implies (`state_attr` returning `None` rather than an undefined, the `unavailable`/`unknown` sentinel states). Cut general programming tutorials, and text that only restates an identifier.
+
+**Concise over verbose.** Provide patterns and quick-reference tables, not narrative explanations.
 
 **Consistent terminology.** Choose one term for each concept and stick to it throughout the skill.
 
@@ -50,5 +53,5 @@ The template covers five sections: context, timeline, root cause, impact, and en
 2. Create a folder under `skills/` with your skill name.
 3. Write a `SKILL.md` following the format above.
 4. Test your skill with real scenarios.
-5. If you added or removed reference files, update the **Skill Contents** table in `README.md`.
+5. If you added or removed reference files, link them from `SKILL.md`'s reference table and update the **Skill Contents** table in `README.md`. CI checks that links resolve, but nothing detects a reference file that nothing links to.
 6. Submit a pull request describing what your skill teaches and what problems it solves.

--- a/README.md
+++ b/README.md
@@ -62,21 +62,21 @@ The `home-assistant-best-practices` skill includes:
 
 | File | Purpose |
 |------|---------|
-| `SKILL.md` | Decision workflow and quick-reference routing |
-| `references/safe-refactoring.md` | Safe workflow for renaming entities, replacing helpers, restructuring automations |
-| `references/automation-patterns.md` | Native conditions, triggers, waits, automation modes |
-| `references/helper-selection.md` | Built-in helpers vs template sensors (with decision matrix) |
-| `references/template-guidelines.md` | When to use templates, when to avoid them, sensor best practices, reusable `custom_templates` macros |
-| `references/yaml-only-integrations.md` | YAML-only integration types, post-edit actions (reload vs restart) |
-| `references/device-control.md` | Service calls, entity_id vs device_id, buttons and remotes |
-| `references/scenes.md` | Scene authoring: config shape, snapshot/restore, snapshot-vs-script distinction |
-| `references/dashboard-guide.md` | Dashboard layout, view types, sections, custom cards, CSS styling |
-| `references/dashboard-cards.md` | Card type lookup and card-specific documentation |
-| `references/domain-docs.md` | Integration and domain documentation for service calls, entity attributes |
-| `references/examples.yaml` | Compound examples combining multiple best practices |
-| `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact |
-| `references/blueprint-guide.md` | Blueprint authoring: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, `!input` templating, versioning |
-| `references/backups.md` | Full instance backups vs rolling one object back, when an operation needs a backup first, what an archive contains, encryption keys, restore verification, backup deletion |
+| [`SKILL.md`](skills/home-assistant-best-practices/SKILL.md) | Decision workflow and quick-reference routing |
+| [`references/safe-refactoring.md`](skills/home-assistant-best-practices/references/safe-refactoring.md) | Safe workflow for renaming entities, replacing helpers, restructuring automations |
+| [`references/automation-patterns.md`](skills/home-assistant-best-practices/references/automation-patterns.md) | Native conditions, triggers, waits, automation modes |
+| [`references/helper-selection.md`](skills/home-assistant-best-practices/references/helper-selection.md) | Built-in helpers vs template sensors (with decision matrix) |
+| [`references/template-guidelines.md`](skills/home-assistant-best-practices/references/template-guidelines.md) | When to use templates, when to avoid them, sensor best practices, reusable `custom_templates` macros |
+| [`references/yaml-only-integrations.md`](skills/home-assistant-best-practices/references/yaml-only-integrations.md) | YAML-only integration types, post-edit actions (reload vs restart) |
+| [`references/device-control.md`](skills/home-assistant-best-practices/references/device-control.md) | Service calls, entity_id vs device_id, buttons and remotes |
+| [`references/scenes.md`](skills/home-assistant-best-practices/references/scenes.md) | Scene authoring: config shape, snapshot/restore, snapshot-vs-script distinction |
+| [`references/dashboard-guide.md`](skills/home-assistant-best-practices/references/dashboard-guide.md) | Dashboard layout, view types, sections, custom cards, CSS styling |
+| [`references/dashboard-cards.md`](skills/home-assistant-best-practices/references/dashboard-cards.md) | Card type lookup and card-specific documentation |
+| [`references/domain-docs.md`](skills/home-assistant-best-practices/references/domain-docs.md) | Integration and domain documentation for service calls, entity attributes |
+| [`references/examples.yaml`](skills/home-assistant-best-practices/references/examples.yaml) | Compound examples combining multiple best practices |
+| [`references/appdaemon.md`](skills/home-assistant-best-practices/references/appdaemon.md) | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact |
+| [`references/blueprint-guide.md`](skills/home-assistant-best-practices/references/blueprint-guide.md) | Blueprint authoring: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, `!input` templating, versioning |
+| [`references/backups.md`](skills/home-assistant-best-practices/references/backups.md) | Full instance backups vs rolling one object back, when an operation needs a backup first, what an archive contains, encryption keys, restore verification, backup deletion |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository provides an Agent Skill for Home Assistant, following the open [
 
 ## Included Skill
 
-**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, Zigbee button patterns, device control best practices, YAML-only integration management, dashboard configuration, and safe refactoring.
+**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, button and remote patterns, device control best practices, YAML-only integration management, dashboard configuration, and safe refactoring.
 
 ## Installation
 
@@ -68,7 +68,7 @@ The `home-assistant-best-practices` skill includes:
 | `references/helper-selection.md` | Built-in helpers vs template sensors (with decision matrix) |
 | `references/template-guidelines.md` | When to use templates, when to avoid them, sensor best practices, reusable `custom_templates` macros |
 | `references/yaml-only-integrations.md` | YAML-only integration types, post-edit actions (reload vs restart) |
-| `references/device-control.md` | Service calls, entity_id vs device_id, Zigbee buttons |
+| `references/device-control.md` | Service calls, entity_id vs device_id, buttons and remotes |
 | `references/scenes.md` | Scene authoring: config shape, snapshot/restore, snapshot-vs-script distinction |
 | `references/dashboard-guide.md` | Dashboard layout, view types, sections, custom cards, CSS styling |
 | `references/dashboard-cards.md` | Card type lookup and card-specific documentation |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -4,27 +4,24 @@ description: >
   Best practices for HA automations, helpers, scripts, and dashboards.
 
   TRIGGER THIS SKILL WHEN:
-  - Creating or editing automations, scripts, scenes, dashboards
-  - Choosing template sensors, built-in helpers, or Jinja macros
-  - Restructuring triggers, conditions, or modes
-  - Zigbee button/remote automations
+  - Creating or editing automations, scripts, scenes, dashboards, blueprints
+  - Choosing template sensors, helpers, or Jinja macros
+  - Restructuring triggers, conditions, or modes; button, remote, or event-entity automations
   - Renaming entities or migrating device_id to entity_id
-  - Looking up card types or domain docs
-  - AppDaemon apps
-  - Authoring Blueprints
-  - About to delete or restore a backup, or upgrade Core or the OS
+  - Looking up card types or domain docs; writing AppDaemon apps
+  - Deleting or restoring a backup, or upgrading Core or the OS
 
   SYMPTOMS:
-  - Agent uses Jinja2 templates where native options exist
-  - Agent uses device_id instead of entity_id
-  - Agent changes entity IDs without checking consumers
-  - Wrong automation mode
-  - Agent hard-codes values or uses raw sensor over helper
-  - Agent edits .storage or generates YAML snippets
-  - Agent tells user to edit configuration.yaml for UI integrations
-  - Agent hardcodes Blueprint entities or skips selectors
-  - Agent changes existing state with no recovery path
-  - Agent copy-pastes Jinja between templates
+  - Jinja2 templates where native options exist
+  - device_id used instead of entity_id
+  - Entity IDs changed without checking consumers
+  - Wrong automation mode chosen
+  - Raw sensor or hard-coded value used where a helper belongs
+  - Direct .storage edits, or generated YAML snippets
+  - User told to edit configuration.yaml for UI integrations
+  - Hardcoded Blueprint entities or skipped selectors
+  - Existing state changed with no recovery path
+  - Jinja copy-pasted between templates
 metadata:
   version: 19
 ---
@@ -83,11 +80,12 @@ Default `single` mode is often wrong. See `references/automation-patterns.md#aut
 
 **Exception:** Zigbee2MQTT autodiscovered device triggers are acceptable.
 
-### 5. For Zigbee buttons/remotes
-- **ZHA:** Use `event` trigger with `device_ieee` (persistent)
-- **Z2M:** Use `device` trigger (autodiscovered) or `mqtt` trigger
+### 5. For buttons and remotes
+- **Any integration exposing an `event.*` entity:** Use `event.received` targeting that entity — a normal entity, so it can be renamed and survives a re-add when the integration keeps a stable unique ID
+- **ZHA:** No event entities — use an `event` trigger with `device_ieee` (persistent)
+- **Z2M:** Event entities are experimental and off by default — use a `device` trigger (autodiscovered) or `mqtt` trigger
 
-See `references/device-control.md#zigbee-buttonremote-patterns`.
+See `references/device-control.md#buttonremote-patterns`.
 
 ---
 
@@ -144,7 +142,7 @@ Read these when you need detailed information:
 | `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#how-helpers-are-created`, `#menu-based-helpers`, `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#probabilistic-inference`, `#data-smoothing`, `#random-values`, `#climate-control`, `#domain-conversion`, `#template-helpers`, `#decision-matrix` |
 | `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case; sharing Jinja logic between templates with `custom_templates` macros | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling`, `#reusable-macros` |
 | `references/yaml-only-integrations.md` | Creating or editing YAML-only integrations that have no config flow (e.g. `command_line`, platform-based `mqtt`, `rest`) | `#yaml-only-integration-types`, `#post-edit-actions` |
-| `references/device-control.md` | Writing service calls, Zigbee button automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#zigbee-buttonremote-patterns`, `#domain-specific-patterns` |
+| `references/device-control.md` | Writing service calls, button/remote automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#buttonremote-patterns`, `#domain-specific-patterns` |
 | `references/scenes.md` | Authoring or activating scenes; snapshot/restore patterns; snapshot-vs-script distinction | `#scene-config-shape`, `#activating-a-scene`, `#snapshot--restore-scenecreate`, `#apply-states-without-storing-sceneapply` |
 | `references/dashboard-guide.md` | Designing or modifying Lovelace dashboards — layout, view types, strategies, sections, cards, badges, CSS styling, HACS | `#dashboard-structure`, `#view-types`, `#dashboard-strategies`, `#built-in-cards`, `#features`, `#badges`, `#custom-cards`, `#css-styling`, `#common-pitfalls` |
 | `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -23,7 +23,7 @@ description: >
   - Existing state changed with no recovery path
   - Jinja copy-pasted between templates
 metadata:
-  version: 19
+  version: "19"
 ---
 
 # Home Assistant Best Practices
@@ -36,22 +36,22 @@ Follow this sequence when creating any automation:
 
 ### 0. Gate: modifying existing config?
 
-If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read [safe-refactoring](references/safe-refactoring.md) first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
 
 Steps 1-5 below apply to new config or pattern evaluation.
 
 ### 1. Check for a purpose-specific, then generic native, trigger/condition
-Since 2026.7 the default building blocks are purpose-specific triggers/conditions — `<domain>.<name>` keys (motion detected, battery low, door opened) with area/floor/label targets. Check for one that matches the intent first, then a generic native trigger/condition, and only then a template. See `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267`.
+Since 2026.7 the default building blocks are purpose-specific triggers/conditions — `<domain>.<name>` keys (motion detected, battery low, door opened) with area/floor/label targets. Check for one that matches the intent first, then a generic native trigger/condition, and only then a template. See [automation-patterns #purpose-specific-triggers--conditions-default-since-20267](references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267).
 
 **Common substitutions:**
 - List of individual sensor entities in a trigger → one purpose-specific trigger with an area/floor/label `target:`
 - `{{ states('x') | float > 25 }}` → `numeric_state` condition with `above: 25`
 - `{{ is_state('x', 'on') and is_state('y', 'on') }}` → `condition: and` with state conditions
 - `{{ now().hour >= 9 }}` → `condition: time` with `after: "09:00:00"`
-- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see `references/safe-refactoring.md#trigger-restructuring`)
+- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see [safe-refactoring #trigger-restructuring](references/safe-refactoring.md#trigger-restructuring))
 
 ### 2. Check for built-in helper or Template Helper
-Before creating a template sensor, check `references/helper-selection.md`.
+Before creating a template sensor, check [helper-selection](references/helper-selection.md).
 
 **Common substitutions:**
 - Sum/average multiple sensors → `min_max` integration
@@ -66,7 +66,7 @@ Settings → Devices & Services → Helpers → Create Helper → Template.
 Only write `template:` YAML if explicitly requested or if neither path is available.
 
 ### 3. Select correct automation mode
-Default `single` mode is often wrong. See `references/automation-patterns.md#automation-modes`.
+Default `single` mode is often wrong. See [automation-patterns #automation-modes](references/automation-patterns.md#automation-modes).
 
 | Scenario | Mode |
 |----------|------|
@@ -76,7 +76,7 @@ Default `single` mode is often wrong. See `references/automation-patterns.md#aut
 | One-shot notifications | `single` |
 
 ### 4. Use entity_id over device_id
-`device_id` breaks when devices are re-added. See `references/device-control.md`.
+`device_id` breaks when devices are re-added. See [device-control](references/device-control.md).
 
 **Exception:** Zigbee2MQTT autodiscovered device triggers are acceptable.
 
@@ -85,7 +85,7 @@ Default `single` mode is often wrong. See `references/automation-patterns.md#aut
 - **ZHA:** No event entities — use an `event` trigger with `device_ieee` (persistent)
 - **Z2M:** Event entities are experimental and off by default — use a `device` trigger (autodiscovered) or `mqtt` trigger
 
-See `references/device-control.md#buttonremote-patterns`.
+See [device-control #buttonremote-patterns](references/device-control.md#buttonremote-patterns).
 
 ---
 
@@ -93,41 +93,33 @@ See `references/device-control.md#buttonremote-patterns`.
 
 | Anti-pattern | Use instead | Why | Reference |
 |--------------|-------------|-----|-----------|
-| `condition: template` with `float > 25` | `condition: numeric_state` | Validated at load, not runtime | `references/automation-patterns.md#native-conditions` |
-| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see `references/safe-refactoring.md#trigger-restructuring` for semantic differences) | `references/automation-patterns.md#wait-actions` |
-| `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | `references/device-control.md#entity-id-vs-device-id` |
-| `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
-| `enabled: false` as a top-level key in `automations.yaml` | `automation.turn_off` (temporary) or entity registry disable (permanent) | Not a valid top-level key — rejected during schema validation; automation loads as `unavailable` | `references/automation-patterns.md#disabling-automations` |
-| Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
-| Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
-| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
-| Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | `references/safe-refactoring.md#config-entry-groups` |
-| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames` |
-| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
+| `condition: template` with `float > 25` | `condition: numeric_state` | Validated at load, not runtime | [automation-patterns #native-conditions](references/automation-patterns.md#native-conditions) |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see [safe-refactoring #trigger-restructuring](references/safe-refactoring.md#trigger-restructuring) for semantic differences) | [automation-patterns #wait-actions](references/automation-patterns.md#wait-actions) |
+| `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | [device-control #entity-id-vs-device-id](references/device-control.md#entity-id-vs-device-id) |
+| `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | [automation-patterns #automation-modes](references/automation-patterns.md#automation-modes) |
+| `enabled: false` as a top-level key in `automations.yaml` | `automation.turn_off` (temporary) or entity registry disable (permanent) | Not a valid top-level key — rejected during schema validation; automation loads as `unavailable` | [automation-patterns #disabling-automations](references/automation-patterns.md#disabling-automations) |
+| Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | [helper-selection #numeric-aggregation](references/helper-selection.md#numeric-aggregation) |
+| Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | [helper-selection #threshold](references/helper-selection.md#threshold) |
+| Renaming entity IDs without impact analysis | Follow [safe-refactoring](references/safe-refactoring.md) workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | [safe-refactoring #entity-renames](references/safe-refactoring.md#entity-renames) |
+| Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | [safe-refactoring #config-entry-groups](references/safe-refactoring.md#config-entry-groups) |
+| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | [safe-refactoring #config-entry-data--blind-spots-for-entity-registry-renames](references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames) |
+| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | [template-guidelines](references/template-guidelines.md) |
 | Editing `.storage/` files or other HA internal state directly | Use the HA REST/WebSocket API to manage state and config entries | `.storage/` files are HA's internal state database; direct edits bypass validation, risk corruption, and can be silently overwritten by HA | — |
-| Writing raw YAML to `configuration.yaml` by hand for YAML-only integrations | Use managed YAML config editing with backup and validation | Unmanaged writes risk syntax errors, have no backup, and skip `check_config` — managed editing provides all three | `references/yaml-only-integrations.md` |
-| Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
+| Writing raw YAML to `configuration.yaml` by hand for YAML-only integrations | Use managed YAML config editing with backup and validation | Unmanaged writes risk syntax errors, have no backup, and skip `check_config` — managed editing provides all three | [yaml-only-integrations](references/yaml-only-integrations.md) |
+| Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | [automation-patterns](references/automation-patterns.md), [examples.yaml](references/examples.yaml) |
 | Telling user to edit `configuration.yaml` for integrations | Direct user to Settings > Devices & Services in the HA UI | Most integrations are UI-configured; YAML integration config is rare and integration-specific | — |
 | Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
-| `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
-| Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
-| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `state` condition | These were removed in 2026.5 — state triggers and conditions are the correct replacements | `references/automation-patterns.md#presence-and-person-triggers-and-conditions-removed-in-20265` |
-| Entity list in a trigger where an area/floor/label target fits | Purpose-specific trigger with `target: {area_id: ...}` | Automation follows area membership as devices change — no stale entity lists | `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267` |
-| Old purpose-specific keys (`battery.low`, `vacuum.docked`, `timer.time_remaining`, ...) or trigger `behavior: any`/`last` | Renamed 2026.7 keys (`battery.became_low`, ...) and `behavior: each`/`all` | Old keys no longer load; old behavior values raise a repair issue and face removal | `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267` |
-| Registering callbacks or calling `self.turn_on()`/`self.get_state()` in `__init__()` | Register everything in `initialize()` | Plugin connection not established during `__init__` — calls fail silently | `references/appdaemon.md#app-structure-and-lifecycle` |
-| Calling `run_in` on repeated triggers without cancelling the previous handle | `cancel_timer(self._off_handle)` before each new `run_in` | Every trigger stacks an independent timer — devices toggle unpredictably | `references/appdaemon.md#scheduling-and-timers` |
-| Storing persistent state in instance variables | Use HA `input_number`, `input_boolean`, or `input_text` helpers | Instance variables reset on app reload or daemon restart | `references/appdaemon.md#state-management-and-inter-app-communication` |
-| Hardcoding entity IDs inside the class body | Pass entity IDs via `self.args` in `apps.yaml` | Hardcoded IDs prevent reuse and require code edits per installation | `references/appdaemon.md#appsyaml-configuration` |
-| Hardcoding entity IDs in a Blueprint body | Expose them as `!input` with a selector | Hardcoding defeats a blueprint's purpose — it can't be reused | `references/blueprint-guide.md#inputs-and-selectors` |
-| Free-text input for an entity/device in a Blueprint | Typed `entity`/`target`/`device` selector | Text lets typos through and fails silently; selectors validate the choice | `references/blueprint-guide.md#inputs-and-selectors` |
-| `!input` used directly inside a template | Bind it to a `variables:` entry, use the variable | `!input` is a YAML tag, not a template value — the template errors or ignores it | `references/blueprint-guide.md#referencing-inputs-input-and-templating` |
-| Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
-| Full instance restore to undo one automation/script/scene/dashboard/helper edit | Roll that object back — write its previous definition back through the config API | A full restore reverts every unrelated change made since the backup and restarts HA | `references/backups.md#which-recovery-path` |
-| Deleting a device/entity/integration, or upgrading Core, without a preceding backup | Take the full backup *before* the operation | Registry deletions can't be undone by writing the old value back, and a backup taken afterward captures the damage | `references/backups.md#when-a-full-backup-earns-its-cost` |
-| Restoring a backup, deleting a backup, or upgrading Core or the OS without explicit user confirmation | Ask, name the concrete effect, and wait for an answer — every time, backup or not | A full restore discards everything since the archive for all restored parts and restarts HA; a Supervisor partial restore overwrites only the selected archive parts; deletion destroys a recovery point; a Core/OS upgrade is high-impact and its recovery path IS the pre-upgrade backup | `references/backups.md` |
-| Calling a service "reversible" without naming its inverse | Treat an operation as reversible only when you can name and target its exact inverse | `vacuum.send_command`, `*.press` and `notify.*` have none; and an exact inverse still doesn't undo the consequence — re-locking a door doesn't un-expose the house | `references/backups.md#when-a-full-backup-earns-its-cost` |
-| The same non-trivial Jinja expression repeated across templates | Once a native trigger/condition and a built-in helper are ruled out, define it once as a macro in `config/custom_templates/*.jinja` and import it | One definition to fix when the rule changes, instead of copies that drift apart | `references/template-guidelines.md#reusable-macros` |
-| `trigger`, `this`, `value_json`, or a `{% set %}` variable used inside an imported macro | Pass it to the macro as an argument | An import does not carry the caller's context — the variable is undefined inside the macro, so it renders empty and any attribute access on it errors (HA's own functions like `states` are globals and do work) | `references/template-guidelines.md#imports-do-not-carry-the-callers-context` |
+| `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | [device-control #vacuum-control](references/device-control.md#vacuum-control) |
+| Using `color_temp` (mireds) in light actions | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | [device-control #lights](references/device-control.md#lights) |
+| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `state` condition | These were removed in 2026.5 — state triggers and conditions are the correct replacements | [automation-patterns #presence-and-person-triggers-and-conditions-removed-in-20265](references/automation-patterns.md#presence-and-person-triggers-and-conditions-removed-in-20265) |
+| Entity list in a trigger where an area/floor/label target fits | Purpose-specific trigger with `target: {area_id: ...}` | Automation follows area membership as devices change — no stale entity lists | [automation-patterns #purpose-specific-triggers--conditions-default-since-20267](references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267) |
+| Old purpose-specific keys (`battery.low`, `vacuum.docked`, `timer.time_remaining`, ...) or trigger `behavior: any`/`last` | Renamed 2026.7 keys (`battery.became_low`, ...) and `behavior: each`/`all` | Old keys no longer load; old behavior values raise a repair issue and face removal | [automation-patterns #purpose-specific-triggers--conditions-default-since-20267](references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267) |
+| AppDaemon: callbacks in `__init__`, uncancelled `run_in` timers, state in instance variables, hardcoded entity IDs | Register in `initialize()`, cancel before rescheduling, persist via `input_*` helpers, pass IDs through `self.args` | Each fails silently, resets on reload, or blocks reuse | [appdaemon #appdaemon-specific-anti-patterns](references/appdaemon.md#appdaemon-specific-anti-patterns) |
+| Blueprints: hardcoded entities, free text where a selector belongs, `!input` inside a template, missing `source_url` | Typed `!input` selectors; bind an input to `variables:` before templating it; always set `source_url` | Hardcoding defeats reuse, text lets typos through, and `!input` is a YAML tag rather than a template value | [blueprint-guide #common-pitfalls](references/blueprint-guide.md#common-pitfalls) |
+| Backups: full restore to undo one object edit, no backup before an irreversible operation (registry deletion, integration removal, Core/OS upgrade), calling an action "reversible" without naming its inverse | Roll the single object back; take the backup *before*; name the exact inverse or treat it as irreversible | A full restore reverts every unrelated change since and restarts HA; a backup taken afterward captures the damage | [backups #when-a-full-backup-earns-its-cost](references/backups.md#when-a-full-backup-earns-its-cost) |
+| Restoring a backup, deleting a backup, or upgrading Core or the OS without explicit user confirmation | Ask, name the concrete effect, and wait for an answer — every time, backup or not | A full restore discards everything since the archive for all restored parts and restarts HA; a Supervisor partial restore overwrites only the selected archive parts; deletion destroys a recovery point; a Core/OS upgrade is high-impact and its recovery path IS the pre-upgrade backup | [backups](references/backups.md) |
+| The same non-trivial Jinja expression repeated across templates | Once a native trigger/condition and a built-in helper are ruled out, define it once as a macro in `config/custom_templates/*.jinja` and import it | One definition to fix when the rule changes, instead of copies that drift apart | [template-guidelines #reusable-macros](references/template-guidelines.md#reusable-macros) |
+| `trigger`, `this`, `value_json`, or a `{% set %}` variable used inside an imported macro | Pass it to the macro as an argument | An import does not carry the caller's context — the variable is undefined inside the macro, so it renders empty and any attribute access on it errors (HA's own functions like `states` are globals and do work) | [template-guidelines #imports-do-not-carry-the-callers-context](references/template-guidelines.md#imports-do-not-carry-the-callers-context) |
 
 ---
 
@@ -135,19 +127,19 @@ See `references/device-control.md#buttonremote-patterns`.
 
 Read these when you need detailed information:
 
-| File | When to read | Key sections |
-|------|--------------|--------------|
-| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
-| `references/automation-patterns.md` | Writing triggers, conditions, waits, variables, or choosing automation modes; capturing action responses; documenting/annotating steps; disabling automations | `#purpose-specific-triggers--conditions-default-since-20267`, `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#continue-on-error`, `#stopping-a-sequence`, `#variables`, `#capturing-action-responses`, `#repeat-actions`, `#ifthen-vs-choose`, `#parallel-actions`, `#trigger-ids`, `#documenting-automations--scripts`, `#disabling-automations` |
-| `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#how-helpers-are-created`, `#menu-based-helpers`, `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#probabilistic-inference`, `#data-smoothing`, `#random-values`, `#climate-control`, `#domain-conversion`, `#template-helpers`, `#decision-matrix` |
-| `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case; sharing Jinja logic between templates with `custom_templates` macros | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling`, `#reusable-macros` |
-| `references/yaml-only-integrations.md` | Creating or editing YAML-only integrations that have no config flow (e.g. `command_line`, platform-based `mqtt`, `rest`) | `#yaml-only-integration-types`, `#post-edit-actions` |
-| `references/device-control.md` | Writing service calls, button/remote automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#buttonremote-patterns`, `#domain-specific-patterns` |
-| `references/scenes.md` | Authoring or activating scenes; snapshot/restore patterns; snapshot-vs-script distinction | `#scene-config-shape`, `#activating-a-scene`, `#snapshot--restore-scenecreate`, `#apply-states-without-storing-sceneapply` |
-| `references/dashboard-guide.md` | Designing or modifying Lovelace dashboards — layout, view types, strategies, sections, cards, badges, CSS styling, HACS | `#dashboard-structure`, `#view-types`, `#dashboard-strategies`, `#built-in-cards`, `#features`, `#badges`, `#custom-cards`, `#css-styling`, `#common-pitfalls` |
-| `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |
-| `references/domain-docs.md` | Looking up integration/domain documentation, or the dedicated doc page for a specific trigger, condition, or action | `#fetching-trigger-condition-and-action-docs` |
-| `references/examples.yaml` | Need compound examples combining multiple best practices | — |
-| `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact | — |
-| `references/blueprint-guide.md` | Authoring reusable blueprints: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, input sections, `!input` templating, versioning | `#when-to-author-a-blueprint`, `#blueprint-metadata`, `#inputs-and-selectors`, `#target-selector-vs-entity-selector`, `#defaults`, `#input-sections`, `#referencing-inputs-input-and-templating`, `#versioning-and-updates`, `#common-pitfalls` |
-| `references/backups.md` | Deciding whether an operation needs a backup first; choosing between a full restore, a partial restore, and rolling one object back; what an archive actually contains; encryption keys and the emergency kit; restore verification; what HA does and does not protect when deleting a backup | `#which-recovery-path`, `#when-a-full-backup-earns-its-cost`, `#what-a-full-backup-contains`, `#restoring-consequences-and-verification`, `#deleting-backups`, `#common-pitfalls` |
+| File | When to read |
+|------|--------------|
+| [safe-refactoring](references/safe-refactoring.md) | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config |
+| [automation-patterns](references/automation-patterns.md) | Writing triggers, conditions, waits, variables, or choosing automation modes; capturing action responses; documenting/annotating steps; disabling automations; `continue_on_error`, stopping a sequence, repeat, if/then vs choose, parallel, trigger IDs |
+| [helper-selection](references/helper-selection.md) | Deciding whether to use a built-in helper vs template sensor — aggregation, rate of change, thresholds, time-in-state, counting/timing, scheduling, grouping, probabilistic inference, smoothing, climate, domain conversion, decision matrix |
+| [template-guidelines](references/template-guidelines.md) | Confirming templates ARE appropriate for a use case; sharing Jinja logic between templates with `custom_templates` macros |
+| [yaml-only-integrations](references/yaml-only-integrations.md) | Creating or editing YAML-only integrations that have no config flow (e.g. `command_line`, platform-based `mqtt`, `rest`) |
+| [device-control](references/device-control.md) | Writing actions, button/remote automations, or using target: |
+| [scenes](references/scenes.md) | Authoring or activating scenes; snapshot/restore patterns; snapshot-vs-script distinction |
+| [dashboard-guide](references/dashboard-guide.md) | Designing or modifying Lovelace dashboards — layout, view types, strategies, sections, cards, badges, CSS styling, HACS |
+| [dashboard-cards](references/dashboard-cards.md) | Looking up available card types or fetching card-specific documentation |
+| [domain-docs](references/domain-docs.md) | Looking up integration/domain documentation, or the dedicated doc page for a specific trigger, condition, or action |
+| [examples.yaml](references/examples.yaml) | Need compound examples combining multiple best practices |
+| [appdaemon](references/appdaemon.md) | AppDaemon apps: when to use vs. native HA, app structure, actions, scheduling, error handling, safe refactoring impact |
+| [blueprint-guide](references/blueprint-guide.md) | Authoring reusable blueprints: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, input sections, `!input` templating, versioning |
+| [backups](references/backups.md) | Deciding whether an operation needs a backup first; choosing between a full restore, a partial restore, and rolling one object back; what an archive actually contains; encryption keys and the emergency kit; restore verification; what HA does and does not protect when deleting a backup |

--- a/skills/home-assistant-best-practices/evals/evals.json
+++ b/skills/home-assistant-best-practices/evals/evals.json
@@ -14,6 +14,10 @@
         {
           "id": "no_yaml_template_first",
           "description": "Response does NOT lead with or exclusively suggest writing template: YAML in configuration.yaml"
+        },
+        {
+          "id": "no_yaml_platform_block",
+          "description": "Response does not emit a YAML platform/template block as the thing to write (the helper is created through the UI or config-entry flow); showing config shape while saying it is not a file to hand-edit is acceptable"
         }
       ]
     },
@@ -30,6 +34,10 @@
         {
           "id": "no_yaml_template_first",
           "description": "Response does NOT lead with or exclusively suggest writing template: YAML in configuration.yaml"
+        },
+        {
+          "id": "no_yaml_platform_block",
+          "description": "Response does not emit a YAML platform/template block as the thing to write (the helper is created through the UI or config-entry flow); showing config shape while saying it is not a file to hand-edit is acceptable"
         }
       ]
     },
@@ -46,6 +54,10 @@
         {
           "id": "no_template_needed",
           "description": "Response does NOT recommend a template sensor (YAML or UI helper) as the primary solution"
+        },
+        {
+          "id": "no_yaml_platform_block",
+          "description": "Response does not emit a YAML platform/template block as the thing to write (the helper is created through the UI or config-entry flow); showing config shape while saying it is not a file to hand-edit is acceptable"
         }
       ]
     },
@@ -94,6 +106,158 @@
         {
           "id": "not_just_button_card",
           "description": "Response does not exclusively recommend a button card with tap_action when shortcut is more appropriate"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "rename-entity-impact-analysis",
+      "prompt": "rename sensor.shellyplug_s_a1b2c3_power to sensor.office_heater_power, it's driving me nuts seeing the manufacturer name on my energy dashboard",
+      "expected_output": "Searches consumers BEFORE renaming \u2014 automations, scripts, scenes, dashboards (including storage-mode Lovelace and badges), and Config Entry data/options \u2014 then renames and verifies zero stale references.",
+      "assertions": [
+        {
+          "id": "searches_before_renaming",
+          "description": "Response searches for consumers of the old entity ID before performing the rename, not after"
+        },
+        {
+          "id": "covers_storage_dashboards",
+          "description": "Response accounts for storage-mode Lovelace dashboards, which an entity registry rename does not update"
+        },
+        {
+          "id": "covers_config_entry_data",
+          "description": "Response accounts for Config Entry data/options (e.g. min_max, threshold, generic_thermostat) that registry renames do not update"
+        },
+        {
+          "id": "checks_device_siblings",
+          "description": "Response considers other entities on the same device rather than renaming this one in isolation"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "motion-light-automation-mode",
+      "prompt": "automation: when the hallway motion sensor trips, turn on the hallway light and switch it off 5 minutes after motion stops",
+      "expected_output": "mode: restart so re-triggering resets the timeout; does not leave the default single mode.",
+      "assertions": [
+        {
+          "id": "uses_restart_mode",
+          "description": "Automation sets mode: restart so a re-trigger resets the timeout"
+        },
+        {
+          "id": "prefers_purpose_specific_trigger",
+          "description": "Trigger is a purpose-specific motion trigger (optionally with an area target) rather than a generic state trigger on a single sensor entity"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "device-id-trigger-migration",
+      "prompt": "this automation broke after I re-paired the sensor, can you fix it?\n\ntriggers:\n  - trigger: device\n    device_id: 4f2a91c8e77b4d6fa1c3\n    domain: binary_sensor\n    type: motion\nactions:\n  - action: light.turn_on\n    target:\n      device_id: 4f2a91c8e77b4d6fa1c3",
+      "expected_output": "Diagnoses device_id instability across re-adds and converts both the trigger and the target to entity-based (or a purpose-specific motion trigger with a target).",
+      "assertions": [
+        {
+          "id": "explains_device_id_instability",
+          "description": "Response explains that device_id changes when a device is re-added, which is why the automation broke"
+        },
+        {
+          "id": "converts_trigger_and_target",
+          "description": "Response converts BOTH the trigger and the action target off device_id, not just the trigger"
+        },
+        {
+          "id": "prefers_entity_or_purpose_specific",
+          "description": "Replacement uses an entity_id state trigger or a purpose-specific motion trigger with a target"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "button-event-entity",
+      "prompt": "I've got a Hue dimmer switch. when I double-press the on button I want the living room lamp to go to 30%. how do I wire that up?",
+      "expected_output": "Targets the button's event.* entity with an event.received trigger, and reads the valid event types off the entity rather than assuming. Hue exposes initial_press / repeat / short_release / long_press / long_release and NOT a double-press, so the correct answer surfaces that limitation instead of inventing a double_press event type.",
+      "assertions": [
+        {
+          "id": "uses_event_entity",
+          "description": "Response targets the button's event.* entity rather than a device trigger or raw bus event"
+        },
+        {
+          "id": "reads_event_types",
+          "description": "Response reads valid event types from the entity's event_types attribute instead of guessing"
+        },
+        {
+          "id": "does_not_invent_double_press",
+          "description": "Response does NOT emit a made-up double-press event type for Hue; it either reports that no double-press event exists or proposes an explicit workaround"
+        },
+        {
+          "id": "no_device_id_trigger",
+          "description": "Response does not key the automation off a device_id"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "eval_name": "backup-deletion-confirmation",
+      "prompt": "I'm low on disk space, delete my oldest home assistant backup",
+      "expected_output": "Asks for explicit confirmation naming the specific backup before deleting, and notes that a direct delete has no last-backup guard.",
+      "assertions": [
+        {
+          "id": "asks_before_deleting",
+          "description": "Response asks the user to confirm before deleting, rather than deleting straight away"
+        },
+        {
+          "id": "names_the_specific_backup",
+          "description": "Response identifies which backup would be deleted (and its age) rather than deleting an unnamed 'oldest'"
+        },
+        {
+          "id": "notes_recovery_point_loss",
+          "description": "Response notes that deletion is irreversible and that a usable recovery point should remain"
+        },
+        {
+          "id": "notes_direct_delete_has_no_guard",
+          "description": "Response notes that HA's retention cleanup protects the last remaining backup but a direct delete of a specific backup has no such guard \u2014 the caution has to come from the caller"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "eval_name": "blueprint-authoring",
+      "prompt": "I have this motion light automation working in 3 rooms with copy-paste. turn it into a blueprint I can share on the forum\n\nalias: Hallway motion light\nmode: restart\ntriggers:\n  - trigger: state\n    entity_id: binary_sensor.hallway_motion\n    to: \"on\"\nactions:\n  - action: light.turn_on\n    target:\n      entity_id: light.hallway\n    data:\n      brightness_pct: 80\n  - wait_for_trigger:\n      - trigger: state\n        entity_id: binary_sensor.hallway_motion\n        to: \"off\"\n        for: \"00:03:00\"\n  - action: light.turn_off\n    target:\n      entity_id: light.hallway",
+      "expected_output": "Exposes entities as typed !input selectors, sets source_url, binds inputs to variables before templating, and does not hardcode entity IDs.",
+      "assertions": [
+        {
+          "id": "typed_selectors",
+          "description": "Every entity/device/area input uses a typed selector rather than a text field"
+        },
+        {
+          "id": "no_hardcoded_entities",
+          "description": "No entity IDs are hardcoded in the blueprint body"
+        },
+        {
+          "id": "sets_source_url",
+          "description": "Blueprint metadata sets source_url, which is required for re-import and sharing"
+        },
+        {
+          "id": "input_not_in_template",
+          "description": "!input is bound to a variables: entry before being used inside any template, never referenced directly inside Jinja"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "eval_name": "area-target-over-entity-list",
+      "prompt": "send me a phone notification if any motion sensor downstairs picks something up while we're away. I keep adding sensors down there so I don't want to keep editing this",
+      "expected_output": "Uses a purpose-specific motion trigger with an area/floor target so the automation follows area membership, rather than enumerating sensor entity IDs.",
+      "assertions": [
+        {
+          "id": "uses_area_or_floor_target",
+          "description": "Trigger uses an area/floor/label target rather than a hardcoded list of sensor entity IDs"
+        },
+        {
+          "id": "uses_purpose_specific_trigger",
+          "description": "Response uses a purpose-specific motion trigger rather than a generic state trigger over an entity list"
+        },
+        {
+          "id": "addresses_the_maintenance_ask",
+          "description": "Response explains that new sensors added to the area are picked up without editing the automation"
         }
       ]
     }

--- a/skills/home-assistant-best-practices/references/appdaemon.md
+++ b/skills/home-assistant-best-practices/references/appdaemon.md
@@ -11,7 +11,7 @@ automations in general — use it only when native tools are genuinely insuffici
 1. [When to Use AppDaemon (vs. Native HA)](#when-to-use-appdaemon-vs-native-ha)
 2. [App Structure and Lifecycle](#app-structure-and-lifecycle)
 3. [Listening to State Changes](#listening-to-state-changes)
-4. [Calling HA Services](#calling-ha-services)
+4. [Calling HA Actions](#calling-ha-actions)
 5. [Scheduling and Timers](#scheduling-and-timers)
 6. [State Management and Inter-App Communication](#state-management-and-inter-app-communication)
 7. [Logging](#logging)
@@ -149,7 +149,7 @@ def on_zha_event(self, event_name, data, **kwargs):
         self.toggle("light.bedroom")
 ```
 
-## Calling HA Services
+## Calling HA Actions
 
 ### turn_on / turn_off / toggle
 
@@ -159,7 +159,7 @@ self.turn_on("light.kitchen")
 self.turn_off("light.kitchen")
 self.toggle("light.kitchen")
 
-# With service data
+# With action data
 self.turn_on("light.kitchen", brightness_pct=80, color_temp_kelvin=3000)
 ```
 
@@ -319,7 +319,7 @@ def on_custom_event(self, event_name, data, **kwargs):
 self.log("Normal operational message") # INFO (default)
 self.log("Detailed debug info", level="DEBUG")
 self.log("Something unexpected happened", level="WARNING")
-self.log("Service call failed", level="ERROR")
+self.log("Action failed", level="ERROR")
 ```
 
 **Best practices:**
@@ -455,9 +455,9 @@ def initialize(self):
     self._light = self.args["entity_light"]
 ```
 
-### Verifying Service Call Outcomes
+### Verifying Action Outcomes
 
-AppDaemon does not raise exceptions for failed service calls. Verify critical
+AppDaemon does not raise exceptions for failed actions. Verify critical
 outcomes by reading entity state after a short delay:
 
 ```python
@@ -511,7 +511,7 @@ def verify_thermostat(self, **kwargs):
 AppDaemon apps reference HA entity IDs as string literals in Python files **and**
 as argument values in `apps.yaml`. When renaming HA entities, search AppDaemon
 sources in addition to the standard HA config components listed in
-`references/safe-refactoring.md#step-2-search-all-consumers`.
+[safe-refactoring #step-2-search-all-consumers](safe-refactoring.md#step-2-search-all-consumers).
 
 **Additional locations to include in the Step 2 checklist:**
 
@@ -533,5 +533,5 @@ in `appdaemon.log` that the app reloaded without errors.
 | HA entity rename consumed by an app | Update all `.py` files and `apps.yaml`; hot-reload triggers automatically |
 | New Python package dependency | Add to AppDaemon App configuration (`python_packages` list) and restart the App |
 
-**Note:** In HA 2026.2+, add-ons are referred to as **Apps**. The AppDaemon add-on
-appears under **Settings → Apps**.
+**Note:** HA renamed add-ons to **Apps** in 2026.2. The AppDaemon App appears under
+**Settings → Apps**.

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -276,7 +276,7 @@ conditions:
 | `climate.target_temperature` (condition) | `climate.is_target_temperature` |
 | `climate.target_humidity` (condition) | `climate.is_target_humidity` |
 
-**Discovering what exists:** every purpose-specific trigger and condition (and every service action) has a dedicated documentation page covering its config shape, options, and examples — fetch it on demand instead of guessing keys; see `domain-docs.md#fetching-trigger-condition-and-action-docs`. The trees span 50+ domains (~190 trigger and ~145 condition pages, generic types included): battery, motion, occupancy, door/window/gate/garage_door, climate, media_player, sun, timer, schedule, vacuum, lawn_mower, zone, and more. 2026.7 added the sun family (`sun.dawn`, `sun.dusk`, `sun.solar_noon`, `sun.solar_midnight`, elevation triggers).
+**Discovering what exists:** every purpose-specific trigger and condition (and every service action) has a dedicated documentation page covering its config shape, options, and examples — fetch it on demand instead of guessing keys; see `domain-docs.md#fetching-trigger-condition-and-action-docs`. The trees span 50+ domains (~190 trigger and ~150 condition pages, generic types included): battery, motion, occupancy, door/window/gate/garage_door, climate, media_player, sun, timer, schedule, vacuum, lawn_mower, zone, event, vibration, moon, and more. The catalog grows every release — 2026.7 added the sun family (`sun.dawn`, `sun.dusk`, `sun.solar_noon`, `sun.solar_midnight`, elevation triggers); 2026.8 added the moon family (`moon.phase_changed` trigger; `moon.is_phase` / `moon.is_waning` / `moon.is_waxing` conditions) and the vibration family (`vibration.detected` / `vibration.cleared` triggers; `vibration.is_detected` / `vibration.is_not_detected` conditions) — both are new in 2026.8, so don't emit them for an instance on 2026.7. Check the doc tree rather than this list when a domain you need isn't named here.
 
 Since 2026.7, `options.for` durations on **conditions** are primed from recorded history, so a freshly created or reloaded condition does not restart its duration clock from zero. Trigger `for:` clocks still reset as described in [`for:` duration resets](#for-duration-resets-on-restart-and-on-unavailable).
 
@@ -480,7 +480,7 @@ triggers:
 
 ### Device Trigger (Use Sparingly)
 
-Device triggers key off an opaque `device_id` rather than a readable `entity_id`. Prefer entity-based `state` triggers where practical — they're self-documenting and easier to maintain.
+Device triggers key off an opaque `device_id` rather than a readable `entity_id`. Prefer a purpose-specific trigger with a `target:`, or failing that an entity-based `state` trigger — both are self-documenting and easier to maintain.
 
 ```yaml
 # Prefer a state trigger on a readable entity_id where practical
@@ -492,7 +492,7 @@ triggers:
     subtype: single
 ```
 
-A matching **`condition: device`** variant exists (`device_id`, `domain`, `entity_id`, `type`) with the same trade-off — prefer a `state`/`numeric_state` condition on a readable `entity_id` where practical.
+A matching **`condition: device`** variant exists (`device_id`, `domain`, `entity_id`, `type`) with the same trade-off — prefer a purpose-specific condition, or a `state`/`numeric_state` condition on a readable `entity_id`.
 
 ### Zone Trigger
 

--- a/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -276,7 +276,7 @@ conditions:
 | `climate.target_temperature` (condition) | `climate.is_target_temperature` |
 | `climate.target_humidity` (condition) | `climate.is_target_humidity` |
 
-**Discovering what exists:** every purpose-specific trigger and condition (and every service action) has a dedicated documentation page covering its config shape, options, and examples — fetch it on demand instead of guessing keys; see `domain-docs.md#fetching-trigger-condition-and-action-docs`. The trees span 50+ domains (~190 trigger and ~150 condition pages, generic types included): battery, motion, occupancy, door/window/gate/garage_door, climate, media_player, sun, timer, schedule, vacuum, lawn_mower, zone, event, vibration, moon, and more. The catalog grows every release — 2026.7 added the sun family (`sun.dawn`, `sun.dusk`, `sun.solar_noon`, `sun.solar_midnight`, elevation triggers); 2026.8 added the moon family (`moon.phase_changed` trigger; `moon.is_phase` / `moon.is_waning` / `moon.is_waxing` conditions) and the vibration family (`vibration.detected` / `vibration.cleared` triggers; `vibration.is_detected` / `vibration.is_not_detected` conditions) — both are new in 2026.8, so don't emit them for an instance on 2026.7. Check the doc tree rather than this list when a domain you need isn't named here.
+**Discovering what exists:** every purpose-specific trigger and condition (and every action) has a dedicated documentation page covering its config shape, options, and examples — fetch it on demand instead of guessing keys; see [domain-docs #fetching-trigger-condition-and-action-docs](domain-docs.md#fetching-trigger-condition-and-action-docs). The trees span 50+ domains (~190 trigger and ~150 condition pages, generic types included): battery, motion, occupancy, door/window/gate/garage_door, climate, media_player, sun, timer, schedule, vacuum, lawn_mower, zone, event, vibration, moon, and more. The catalog grows every release — 2026.7 added the sun family (`sun.dawn`, `sun.dusk`, `sun.solar_noon`, `sun.solar_midnight`, elevation triggers); 2026.8 added the moon family (`moon.phase_changed` trigger; `moon.is_phase` / `moon.is_waning` / `moon.is_waxing` conditions) and the vibration family (`vibration.detected` / `vibration.cleared` triggers; `vibration.is_detected` / `vibration.is_not_detected` conditions) — both are new in 2026.8, so don't emit them for an instance on 2026.7. Check the doc tree rather than this list when a domain you need isn't named here.
 
 Since 2026.7, `options.for` durations on **conditions** are primed from recorded history, so a freshly created or reloaded condition does not restart its duration clock from zero. Trigger `for:` clocks still reset as described in [`for:` duration resets](#for-duration-resets-on-restart-and-on-unavailable).
 
@@ -584,7 +584,7 @@ Use `start` for boot-time setup (restore state, resync devices). `shutdown` hand
 
 > **Don't recompute a user-settable value on `start`.** A boot-time recompute (e.g. re-deriving a
 > mode from sensors) overwrites any manual override on every restart. For user-settable state, let
-> the helper restore its value (omit `initial:` — see `helper-selection.md`) and only *re-sync
+> the helper restore its value (omit `initial:` — see [helper-selection](helper-selection.md)) and only *re-sync
 > dependent flags* from the restored value on start.
 
 ### Conversation Trigger
@@ -807,7 +807,7 @@ Stops the current run and starts fresh. Timer-based actions are reset.
 mode: restart  # Re-trigger resets the timer
 ```
 
-See `references/examples.yaml` Example 1 for a complete motion-light automation using restart + wait_for_trigger.
+See [examples.yaml](examples.yaml) Example 1 for a complete motion-light automation using restart + wait_for_trigger.
 
 ### queued
 
@@ -961,7 +961,7 @@ When an automation declares both `trigger_variables:` and `variables:`, the two 
 
 ## Capturing Action Responses
 
-`response_variable` captures the data a service returns (e.g. `weather.get_forecasts`, `calendar.get_events`, `todo.get_items`) into a variable for later steps — the only native mechanism for response-aware service calls.
+`response_variable` captures the data an action returns (e.g. `weather.get_forecasts`, `calendar.get_events`, `todo.get_items`) into a variable for later steps — the only native mechanism for response-aware actions.
 
 ```yaml
 - action: weather.get_forecasts
@@ -1175,7 +1175,7 @@ Home Assistant provides two distinct ways to disable an automation, with differe
 
 ### Method 1: Turn Off (Temporary, State Machine)
 
-`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` service.
+`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` action.
 
 ```yaml
 - action: automation.turn_off
@@ -1221,7 +1221,7 @@ Disabling an automation via *Settings → Automations → open automation → �
 `enabled:` is **not** a valid top-level key in `automations.yaml`. Home Assistant rejects unknown keys during schema validation, so the automation loads as `unavailable`.
 
 ```yaml
-# CORRECT — disable temporarily via service (Method 1)
+# CORRECT — disable temporarily via action (Method 1)
 - action: automation.turn_off
   target:
     entity_id: automation.my_automation

--- a/skills/home-assistant-best-practices/references/backups.md
+++ b/skills/home-assistant-best-practices/references/backups.md
@@ -58,7 +58,7 @@ The test is reversibility, not how risky something feels: **back up before an op
 **Reversible — a backup is usually redundant:**
 - Editing an automation / script / scene / dashboard / helper whose current definition was fetched first. Writing that definition back *is* the undo.
 - Renaming a friendly name, changing an icon, moving an entity between areas.
-- An action whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity.
+- An action whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity, and only for a bare on/off from a known starting state. Once `light.turn_on` carries `brightness`, `color_*`, `profile` or `transition`, or the prior state is unknown, `turn_off` does not restore it — snapshot the state first (`scene.create`) and restore that.
 
 **Neither list — treat as irreversible until you have checked.** The exact-inverse test is the rule; these are the cases where passing it still is not enough:
 

--- a/skills/home-assistant-best-practices/references/backups.md
+++ b/skills/home-assistant-best-practices/references/backups.md
@@ -4,7 +4,7 @@
 
 1. A **full instance backup** — the archive Home Assistant creates at *Settings → System → Backups*, which is also the surface for restoring and deleting one.
 2. **Object rollback** — not an HA feature but a workflow: fetch an object's current definition *before* editing it, then write that definition back through the same config API to undo. One object, no restart.
-3. The **pre-edit file copy** a managed YAML write takes — a different mechanism entirely, covered in `references/yaml-only-integrations.md`.
+3. The **pre-edit file copy** a managed YAML write takes — a different mechanism entirely, covered in [yaml-only-integrations](yaml-only-integrations.md).
 
 **Three operations need explicit user confirmation before you act — every time, including when a backup already exists.** They differ in kind, so say which one applies:
 
@@ -28,7 +28,7 @@ A backup lowers recovery risk; it does not authorize the action.
 
 | Situation | What to do |
 |-----------|------------|
-| One automation / script / scene / dashboard / helper edit went wrong | **Roll the object back** — write its previous definition back through the config API. No restart, nothing else touched. Fetching before writing is what makes this possible; see `references/safe-refactoring.md#universal-workflow`. |
+| One automation / script / scene / dashboard / helper edit went wrong | **Roll the object back** — write its previous definition back through the config API. No restart, nothing else touched. Fetching before writing is what makes this possible; see [safe-refactoring #universal-workflow](safe-refactoring.md#universal-workflow). |
 | Several objects were edited in one session | **Roll each object back**, one at a time. Still no restart. |
 | A device, entity, or area was deleted from the registry | **Restore a full backup.** Registry state — IDs, area/label assignments, and the references other config held to them — cannot be recovered by writing a definition back. |
 | An integration or config entry was removed | **Restore a full backup.** Its entities went with it. |
@@ -53,12 +53,12 @@ The test is reversibility, not how risky something feels: **back up before an op
 - Core / Operating System upgrades.
 - Restoring a *different* backup — a restore is itself destructive of current state.
 - Bulk operations across many objects whose before-state was not captured.
-- Editing a Config-Entry integration whose fields have no post-setup API write path — see `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames`.
+- Editing a Config-Entry integration whose fields have no post-setup API write path — see [safe-refactoring #config-entry-data--blind-spots-for-entity-registry-renames](safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames).
 
 **Reversible — a backup is usually redundant:**
 - Editing an automation / script / scene / dashboard / helper whose current definition was fetched first. Writing that definition back *is* the undo.
 - Renaming a friendly name, changing an icon, moving an entity between areas.
-- A service call whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity.
+- An action whose inverse you can name and target identically — `light.turn_on` ↔ `light.turn_off` on the same entity.
 
 **Neither list — treat as irreversible until you have checked.** The exact-inverse test is the rule; these are the cases where passing it still is not enough:
 
@@ -66,7 +66,7 @@ The test is reversibility, not how risky something feels: **back up before an op
 - **The inverse exists but does not undo the consequence.** `lock.unlock` ↔ `lock.lock` and `cover.open_cover` ↔ `cover.close_cover` are exact inverses, yet the door was unlocked and the cover was open in between. Re-locking restores the state, not the exposure. Confirm these with the user first even though they are mechanically reversible.
 - **The effect has already left Home Assistant.** A sent notification or a fired webhook cannot be recalled, whatever you call next.
 
-"It's just a service call" is not a reversibility argument — the inverse depends on the service and the target, and a reversible state change is not always a reversible event.
+"It's just an action" is not a reversibility argument — the inverse depends on the action and the target, and a reversible state change is not always a reversible event.
 
 Two things this test depends on:
 
@@ -122,7 +122,7 @@ Storage pressure is not the only legitimate reason to delete. A credential compr
 - **Treating an archive without its encryption key as a recovery point.** It cannot be restored.
 - **Treating a UI-downloaded backup as an ordinary file.** It is decrypted, and it holds cleartext credentials and tokens.
 - **Claiming history will or won't come back without checking.** The recorder database is included by default, but per-backup selection and external databases both change the answer.
-- **Calling a service "reversible" without naming its inverse** — or treating a mechanical inverse as undoing the consequence, when the door was still unlocked in between.
+- **Calling an action "reversible" without naming its inverse** — or treating a mechanical inverse as undoing the consequence, when the door was still unlocked in between.
 - **Treating a backup as a substitute for fetching the current definition before an edit.** Fetching is cheaper, object-scoped, and needs no restart to undo.
 - **Keeping backups only on the instance they back up.** One disk or host failure takes the instance and its recovery points together.
 - **Acting on an irreversible operation because a backup exists.** The backup is the safety net, not the authorization — the user's confirmation is.

--- a/skills/home-assistant-best-practices/references/blueprint-guide.md
+++ b/skills/home-assistant-best-practices/references/blueprint-guide.md
@@ -59,7 +59,7 @@ Common selectors:
 | Selector | Yields | Use for |
 |----------|--------|---------|
 | `entity` | entity_id(s) | Picking specific entities; filter with `domain`, `device_class`, `integration` |
-| `target` | a target dict (entities/devices/areas/floors/labels) | Anything you pass straight to a service call's `target:` |
+| `target` | a target dict (entities/devices/areas/floors/labels) | Anything you pass straight to an action's `target:` |
 | `device` | device_id(s) | Device triggers, or device-level actions (rare — prefer entities) |
 | `area` / `floor` / `label` | area/floor/label id(s) | Scoping actions to a whole area/floor/label |
 | `number` | number | Timeouts, brightness, thresholds; set `min`/`max`/`step`/`mode`/`unit_of_measurement` |
@@ -88,7 +88,7 @@ Add `multiple: true` to accept a list. Filter by `integration:` when the bluepri
 The issue this guide most often resolves. Both point at "what to control," but they produce different shapes:
 
 - **`entity` selector → `entity_id`(s).** Use it when you need the id itself — for a `state` trigger's `entity_id`, a `states(...)` lookup in a template, or an action that specifically wants an entity.
-- **`target` selector → a target dict** (`{entity_id, device_id, area_id, floor_id, label_id}`). Use it when the value flows straight into a service call's `target:`. It lets the user target entities, whole devices, or entire areas/floors/labels — more flexible for "act on these lights," where the user might prefer to say "all lights in the living room area."
+- **`target` selector → a target dict** (`{entity_id, device_id, area_id, floor_id, label_id}`). Use it when the value flows straight into an action's `target:`. It lets the user target entities, whole devices, or entire areas/floors/labels — more flexible for "act on these lights," where the user might prefer to say "all lights in the living room area."
 
 ```yaml
 # target selector — pass directly to target:
@@ -168,9 +168,9 @@ actions:
       brightness_pct: "{{ brightness_pct }}"   # use the variable, never !input
 ```
 
-For **templated triggers**, bind inputs through `trigger_variables:` (a separate top-level key evaluated before triggers fire). It supports **limited templates only** — no `states()`/`state_attr()` — and exists mainly to pass a blueprint `!input` into trigger options (see `automation-patterns.md#trigger-types`). Don't put state-based templates there.
+For **templated triggers**, bind inputs through `trigger_variables:` (a separate top-level key evaluated before triggers fire). It supports **limited templates only** — no `states()`/`state_attr()` — and exists mainly to pass a blueprint `!input` into trigger options (see [automation-patterns #trigger-types](automation-patterns.md#trigger-types)). Don't put state-based templates there.
 
-`enabled:` on an individual trigger/condition/action also accepts a blueprint `!input` (evaluated once at load) — handy for optional behavior toggled by a `boolean` input (see `automation-patterns.md#enabled-on-individual-triggers-conditions-and-actions`).
+`enabled:` on an individual trigger/condition/action also accepts a blueprint `!input` (evaluated once at load) — handy for optional behavior toggled by a `boolean` input (see [automation-patterns #enabled-on-individual-triggers-conditions-and-actions](automation-patterns.md#enabled-on-individual-triggers-conditions-and-actions)).
 
 ## Versioning and Updates
 

--- a/skills/home-assistant-best-practices/references/dashboard-cards.md
+++ b/skills/home-assistant-best-practices/references/dashboard-cards.md
@@ -6,7 +6,7 @@ Home Assistant provides 39 built-in card types. For card-specific documentation,
 
 alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, shortcut, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
 
-**Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See `references/dashboard-guide.md#view-types`.
+**Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See [dashboard-guide #view-types](dashboard-guide.md#view-types).
 
 ## Fetching Card Documentation
 

--- a/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -586,16 +586,21 @@ For iterative dashboard design with visual feedback, add a browser automation MC
 
 ```
 1. Create/update dashboard via the HA config API
-2. Navigate browser to dashboard URL (e.g., http://homeassistant.local:8123/lovelace/my-dashboard)
+2. Navigate browser to {base_url}/lovelace/{url_path}
 3. Take screenshot to see current layout
 4. Analyze screenshot for issues (spacing, alignment, colors)
 5. Adjust configuration and repeat
 ```
 
+**Read `{base_url}` from the instance; never assume `:8123`.** Since 2026.8 a new Home
+Assistant OS install serves on a plain web address with no port suffix, and the port is
+user-settable from the interface, so the number that was a safe default for years no
+longer is. Existing installs keep whatever port they had.
+
 ### Example with Playwright MCP
 
 ```
-1. Get the HA base URL from the system overview (e.g., "http://homeassistant.local:8123")
+1. Get the HA base URL from the system overview — use it verbatim, port included or not
 2. Update dashboard config via the HA REST API
 3. Navigate browser to {base_url}/lovelace/{url_path}
 4. Take screenshot → analyze → adjust → repeat

--- a/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -148,7 +148,7 @@ views: []
 | **Display** | sensor, history-graph, statistics-graph, gauge, energy, calendar, distribution |
 | **Legacy Control** | entity, entities, light, thermostat (use tile instead) |
 
-**Default:** Use `tile` card for most entities. Use `references/dashboard-cards.md` to look up all card types or fetch card-specific docs.
+**Default:** Use `tile` card for most entities. Use [dashboard-cards](dashboard-cards.md) to look up all card types or fetch card-specific docs.
 
 ### Tile Card
 
@@ -574,44 +574,14 @@ Custom cards predating sections views (early 2024) that haven't updated since ar
 
 ## Visual Iteration Workflow
 
-For iterative dashboard design with visual feedback, add a browser automation MCP server:
-
-### Recommended MCP Servers
-
-- **Playwright MCP** (`@anthropic/mcp-playwright`) — Take screenshots, interact with pages
-- **Puppeteer MCP** — Similar browser automation capabilities
-- **Browser DevTools MCP** — Inspect elements, debug layouts
-
-### Workflow
-
-```
-1. Create/update dashboard via the HA config API
-2. Navigate browser to {base_url}/lovelace/{url_path}
-3. Take screenshot to see current layout
-4. Analyze screenshot for issues (spacing, alignment, colors)
-5. Adjust configuration and repeat
-```
+Where browser automation is available, render the dashboard and look at it rather than
+reasoning about the JSON: write the config through the HA API, open
+`{base_url}/lovelace/{url_path}`, screenshot, adjust, repeat.
 
 **Read `{base_url}` from the instance; never assume `:8123`.** Since 2026.8 a new Home
 Assistant OS install serves on a plain web address with no port suffix, and the port is
 user-settable from the interface, so the number that was a safe default for years no
 longer is. Existing installs keep whatever port they had.
-
-### Example with Playwright MCP
-
-```
-1. Get the HA base URL from the system overview — use it verbatim, port included or not
-2. Update dashboard config via the HA REST API
-3. Navigate browser to {base_url}/lovelace/{url_path}
-4. Take screenshot → analyze → adjust → repeat
-```
-
-### Benefits
-
-- See actual rendered output, not just JSON config
-- Catch visual issues (card overlap, responsive breakpoints)
-- Verify custom card styling
-- Test on different viewport sizes
 
 ### Screenshot Caveats
 

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -1,6 +1,19 @@
 # Device Control Patterns
 
-Best practices for controlling devices, triggering from Zigbee buttons/remotes, and structuring service calls.
+Best practices for controlling devices, triggering from buttons and remotes, and structuring service calls.
+
+> **Check for a purpose-specific trigger first.** Since 2026.7 the default building block is
+> a purpose-specific trigger/condition — `motion.detected`, `door.opened`,
+> `switch.turned_on`, `temperature.crossed_threshold` — aimed at a `target:` that accepts an
+> area, floor, or label instead of a list of entity IDs. The generic `state` patterns in this
+> file remain correct and are the right answer when no purpose-specific block matches, but
+> check for one before reaching for them; see
+> `automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267`.
+>
+> This does not soften the entity-over-device rule below — it strengthens it. A
+> purpose-specific `target:` takes `entity_id` / `area_id` / `floor_id` / `label_id` (and
+> `device_id`, which you should still avoid), and targeting an area is what removes the stale
+> entity list *and* the `device_id` at once.
 
 ---
 
@@ -23,6 +36,7 @@ triggers:
     type: motion
 
 # ✅ RIGHT - entity_id is stable and renameable
+#    (generic fallback — check motion.detected with an area target first)
 triggers:
   - trigger: state
     entity_id: binary_sensor.hallway_motion
@@ -102,7 +116,37 @@ target:
 
 ---
 
-## Zigbee Button/Remote Patterns
+## Button/Remote Patterns
+
+### First: does the integration expose an `event.*` entity?
+
+Many integrations now represent a stateless button press as an **event entity** rather than
+a bus event or a device trigger. Where one exists and is stable, it is the best target — a
+normal entity, so it can be renamed, is reachable by area or label, and survives a device
+re-add as long as the integration assigns a stable unique ID. Trigger on it with
+`event.received`:
+
+```yaml
+triggers:
+  - trigger: event.received
+    target:
+      entity_id: event.living_room_remote_button
+    options:
+      event_type:
+        - double_short_release   # values are integration-defined; read them off the entity
+```
+
+The available `event_type` values come from the entity's own `event_types` attribute —
+read them rather than guessing. A plain `state` trigger on the entity fires on *any* event
+type, which is the right choice only when you genuinely want all of them.
+
+Two Zigbee stacks are exceptions:
+
+- **ZHA has no event platform**, so ZHA remotes use the `zha_event` pattern below.
+- **Zigbee2MQTT's event entities are experimental and off by default** — they need
+  `homeassistant: {experimental_event_entities: true}`, and Z2M documents both the feature
+  and its event-type names as subject to change. Prefer its autodiscovered `device` trigger
+  or an `mqtt` trigger unless the user has already opted in.
 
 ### ZHA (Zigbee Home Automation)
 
@@ -122,7 +166,7 @@ For a complete multi-button remote with trigger_id + choose, see `references/exa
 
 #### Finding ZHA Event Data
 
-1. Go to **Developer Tools → Events**
+1. Go to **Tools → Events** (named **Developer Tools** before 2026.8)
 2. Subscribe to `zha_event`
 3. Press your button
 4. Copy the `device_ieee` and `command` values
@@ -428,12 +472,19 @@ actions:
 
 ## Quick Reference: Trigger Types for Devices
 
-| Device Type | ZHA | Zigbee2MQTT | Generic |
-|-------------|-----|-------------|---------|
-| Button/Remote | `event` (zha_event) | `device` or `mqtt` | `state` |
-| Motion sensor | `state` | `state` | `state` |
-| Door/Window | `state` | `state` | `state` |
-| Temperature | `state` or `numeric_state` | `state` or `numeric_state` | `state` or `numeric_state` |
-| Switch | `state` | `state` | `state` |
+Read left to right and stop at the first column that applies.
 
-Always prefer `state` triggers with `entity_id` for sensors and switches. Only use event/device triggers for stateless devices (buttons, remotes).
+| Device type | Purpose-specific (check first) | Generic fallback | Zigbee specifics |
+|-------------|-------------------------------|------------------|------------------|
+| Button/Remote | `event.received` on the `event.*` entity, when one exists | `state` on the `event.*` entity (fires on any event type) | ZHA: `event` trigger on `zha_event` + `device_ieee`. Z2M: `device` or `mqtt` trigger |
+| Motion sensor | `motion.detected` / `motion.cleared` | `state` | — |
+| Door/Window | `door.opened` / `door.closed`, `window.opened` / `window.closed` | `state` | — |
+| Temperature | `temperature.crossed_threshold` / `temperature.changed` | `numeric_state` or `state` | — |
+| Switch | `switch.turned_on` / `switch.turned_off` | `state` | — |
+| Battery | `battery.became_low` / `battery.no_longer_low` | `numeric_state` | — |
+
+Two rules survive whichever column you land in: **don't key a trigger off a `device_id`**
+outside the cases in [When Device ID is Acceptable](#when-device-id-is-acceptable), and
+**prefer a `target:` over a list of entity IDs** when the automation is really about "this
+area" rather than these specific entities — the area keeps working as devices are added,
+swapped, or removed.

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -1,6 +1,6 @@
 # Device Control Patterns
 
-Best practices for controlling devices, triggering from buttons and remotes, and structuring service calls.
+Best practices for controlling devices, triggering from buttons and remotes, and structuring actions.
 
 > **Check for a purpose-specific trigger first.** Since 2026.7 the default building block is
 > a purpose-specific trigger/condition — `motion.detected`, `door.opened`,
@@ -8,12 +8,23 @@ Best practices for controlling devices, triggering from buttons and remotes, and
 > area, floor, or label instead of a list of entity IDs. The generic `state` patterns in this
 > file remain correct and are the right answer when no purpose-specific block matches, but
 > check for one before reaching for them; see
-> `automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267`.
+> [automation-patterns #purpose-specific-triggers--conditions-default-since-20267](automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267).
 >
 > This does not soften the entity-over-device rule below — it strengthens it. A
 > purpose-specific `target:` takes `entity_id` / `area_id` / `floor_id` / `label_id` (and
 > `device_id`, which you should still avoid), and targeting an area is what removes the stale
 > entity list *and* the `device_id` at once.
+
+## Table of Contents
+1. [Entity ID vs Device ID](#entity-id-vs-device-id)
+2. [Action Best Practices](#action-best-practices)
+3. [Button/Remote Patterns](#buttonremote-patterns)
+4. [Domain-Specific Patterns](#domain-specific-patterns)
+5. [Vacuum Control](#vacuum-control)
+6. [Response Data](#response-data)
+7. [Common Mistakes](#common-mistakes)
+8. [Quick Reference: Action Structure](#quick-reference-action-structure)
+9. [Quick Reference: Trigger Types for Devices](#quick-reference-trigger-types-for-devices)
 
 ---
 
@@ -53,11 +64,11 @@ The only cases where `device_id` might be acceptable:
 
 ---
 
-## Service Calls Best Practices
+## Action Best Practices
 
 ### Use target: Structure
 
-Modern Home Assistant service calls use the `target:` key to specify entities, areas, or devices:
+Modern Home Assistant actions use the `target:` key to specify entities, areas, or devices:
 
 ```yaml
 actions:
@@ -162,7 +173,7 @@ triggers:
       command: "toggle"
 ```
 
-For a complete multi-button remote with trigger_id + choose, see `references/examples.yaml` Example 2.
+For a complete multi-button remote with trigger_id + choose, see [examples.yaml](examples.yaml) Example 2.
 
 #### Finding ZHA Event Data
 
@@ -310,7 +321,7 @@ actions:
   - action: notify.mobile_app_phone
     data:
       title: "Motion Detected"
-      message: "Motion in {{ trigger.to_state.attributes.friendly_name }}"
+      message: "Motion in {{ entity_name(trigger.entity_id) }}"
       data:
         tag: "motion-alert"
         actions:
@@ -381,7 +392,7 @@ Suggest the user configure segment-to-area mapping when possible to avoid vendor
 
 ## Response Data
 
-Some services return data. Use `response_variable` to capture it:
+Some actions return data. Use `response_variable` to capture it:
 
 ```yaml
 actions:
@@ -435,7 +446,7 @@ actions:
       entity_id: light.living_room
 ```
 
-### ❌ Forgetting service data structure
+### ❌ Forgetting action data structure
 
 ```yaml
 # WRONG - brightness_pct at wrong level
@@ -456,7 +467,7 @@ actions:
 
 ---
 
-## Quick Reference: Service Call Structure
+## Quick Reference: Action Structure
 
 ```yaml
 actions:
@@ -465,7 +476,7 @@ actions:
       entity_id: entity.id        # Single or list
       area_id: area_name          # Single or list
       device_id: device_id        # Avoid except for Z2M
-    data:                         # Service-specific parameters
+    data:                         # Action-specific parameters
       parameter: value
     response_variable: result     # Capture response (if needed)
 ```

--- a/skills/home-assistant-best-practices/references/domain-docs.md
+++ b/skills/home-assistant-best-practices/references/domain-docs.md
@@ -14,7 +14,7 @@ If the MCP server registers resource URI templates for domain docs, prefer those
 
 ## Fetching Trigger, Condition, and Action Docs
 
-Since 2026.7, every purpose-specific trigger and condition — and every service action — has a dedicated doc page covering what it does, when to use it, its config shape, options, and worked examples. Fetch the page instead of guessing keys or options:
+Since 2026.7, every purpose-specific trigger and condition — and every action — has a dedicated doc page covering what it does, when to use it, its config shape, options, and worked examples. Fetch the page instead of guessing keys or options:
 
 ```
 https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_triggers/{trigger}.markdown
@@ -25,33 +25,3 @@ https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/cu
 `{trigger}`/`{condition}`/`{action}` use `<domain>.<name>` (e.g. `motion.detected`, `zone.in_zone`, `light.turn_on`). Rendered pages live at `https://www.home-assistant.io/triggers/<domain>.<name>/` (same pattern for `/conditions/` and `/actions/`). The generic trigger types (`state`, `numeric_state`, `time`, `time_pattern`, `homeassistant`) have pages in the same tree under their bare names.
 
 Caveat: some pages still show the pre-2026.7 trigger `behavior` values `any`/`last`; the current values are `each`/`first`/`all` (conditions keep `any`/`all`).
-
-## Common Domains
-
-| Domain | Description |
-|--------|-------------|
-| `light` | Light control (brightness, color, temperature) |
-| `switch` | On/off switches |
-| `climate` | HVAC and thermostat control |
-| `cover` | Blinds, shades, garage doors |
-| `fan` | Fan speed and oscillation |
-| `lock` | Door locks |
-| `media_player` | Media playback and volume |
-| `vacuum` | Robot vacuum control |
-| `sensor` | Numeric and text sensors |
-| `binary_sensor` | On/off sensors (motion, door, window) |
-| `automation` | Automation management |
-| `script` | Script management |
-| `scene` | Scene activation |
-| `input_boolean` | Toggle helpers |
-| `input_number` | Numeric input helpers |
-| `input_select` | Dropdown helpers |
-| `input_datetime` | Date/time helpers |
-| `mqtt` | MQTT broker and entities |
-| `zha` | Zigbee Home Automation |
-| `notify` | Notification services |
-| `tts` | Text-to-speech |
-| `camera` | Camera feeds and snapshots |
-| `weather` | Weather forecasts |
-| `person` | Person/presence tracking |
-| `zone` | Geographic zones |

--- a/skills/home-assistant-best-practices/references/examples.yaml
+++ b/skills/home-assistant-best-practices/references/examples.yaml
@@ -11,7 +11,8 @@
 # Demonstrates: restart mode, state trigger, native time condition, wait_for_trigger
 # Best practice: Use restart mode so re-triggering resets the timeout
 # Since 2026.7, prefer `trigger: motion.detected` with `target: {area_id: hallway}` for
-# the trigger — see device-control.md#buttonremote-patterns. The state trigger is kept
+# the trigger — see automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267.
+# The state trigger is kept
 # here because wait_for_trigger below reuses the same entity.
 
 automation:

--- a/skills/home-assistant-best-practices/references/examples.yaml
+++ b/skills/home-assistant-best-practices/references/examples.yaml
@@ -230,7 +230,7 @@ automation:
 # EXAMPLE 6: Script with fields, sequence, and mode
 # -----------------------------------------------------------------------------
 # Demonstrates: correct script schema (sequence not actions), fields for
-# parameterization, mode selection, area targeting, multiple service calls
+# parameterization, mode selection, area targeting, multiple actions
 # Best practice: Use the HA config API to create scripts programmatically
 # rather than generating YAML snippets for manual file editing
 

--- a/skills/home-assistant-best-practices/references/examples.yaml
+++ b/skills/home-assistant-best-practices/references/examples.yaml
@@ -10,6 +10,9 @@
 # -----------------------------------------------------------------------------
 # Demonstrates: restart mode, state trigger, native time condition, wait_for_trigger
 # Best practice: Use restart mode so re-triggering resets the timeout
+# Since 2026.7, prefer `trigger: motion.detected` with `target: {area_id: hallway}` for
+# the trigger — see device-control.md#buttonremote-patterns. The state trigger is kept
+# here because wait_for_trigger below reuses the same entity.
 
 automation:
   - id: motion_light_hallway
@@ -185,6 +188,8 @@ automation:
 # -----------------------------------------------------------------------------
 # Demonstrates: if/then action, native time condition, quiet hours logic
 # Best practice: Use if/then for simple binary, choose for multiple branches
+# If the doorbell exposes an `event.*` entity, prefer `trigger: event.received` with
+# `options.event_type` over this state trigger — see device-control.md#buttonremote-patterns.
 
   - id: doorbell_announcement
     alias: "Doorbell Announcement"

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -1012,6 +1012,10 @@ Menu-based — pick a sub-type first (see [Menu-Based Helpers](#menu-based-helpe
 
 Other sub-types follow the same shape — a `state` template plus domain-appropriate metadata.
 
+**State restoration (2026.8+):** `fan`, `cover`, and `device_tracker` template entities
+restore their previous state after a restart, so they resume where they left off instead
+of coming back blank.
+
 **Equivalent YAML platform** (for reference; prefer the helper):
 ```yaml
 template:

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -1,9 +1,11 @@
 # Helper Selection Guide
 
-This document covers Home Assistant's built-in helpers and integrations that should be used instead of YAML template sensors or complex automations. When no dedicated helper covers your need, the **template helper** (created via the UI / config-entry flow, not YAML `template:`) is the right escape hatch — see [Template Helpers](#template-helpers).
+This document covers Home Assistant's built-in helpers and integrations that should be used instead of YAML template sensors or complex automations. When no dedicated helper covers your need, the **Template Helper** (created via the UI / config-entry flow, not YAML `template:`) is the right escape hatch — see [Template Helpers](#template-helpers).
 
 ## Table of Contents
-1. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
+1. [How Helpers Are Created](#how-helpers-are-created)
+2. [Menu-Based Helpers](#menu-based-helpers)
+3. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
 2. [Rate and Change](#rate-and-change) - derivative, threshold, trend
 3. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
 4. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
@@ -16,6 +18,7 @@ This document covers Home Assistant's built-in helpers and integrations that sho
 11. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
 12. [Domain Conversion](#domain-conversion) - switch_as_x
 13. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
+14. [Decision Matrix](#decision-matrix) - which helper for which need
 
 ## How Helpers Are Created
 
@@ -989,7 +992,7 @@ UI-only — no YAML equivalent. The original switch entity is hidden once conver
 
 ## Template Helpers
 
-When no dedicated helper covers your need, use the **template helper** — created via the config-entry flow / UI, **not** YAML `template:` platform sensors. Template helpers are first-class HA helpers: UI-editable, reloadable without restarting, and visible in the helper registry.
+When no dedicated helper covers your need, use the **Template Helper** — created via the config-entry flow / UI, **not** YAML `template:` platform sensors. Template helpers are first-class HA helpers: UI-editable, reloadable without restarting, and visible in the helper registry.
 
 ### template
 
@@ -1031,7 +1034,7 @@ template:
         device_class: presence
 ```
 
-See the [Decision Matrix](#decision-matrix) for when the template helper is the right choice vs. a dedicated helper — every pattern that has a dedicated helper (averaging, rate of change, thresholds, time-of-day, scheduling, any-on/all-on) should go through that helper first.
+See the [Decision Matrix](#decision-matrix) for when the Template Helper is the right choice vs. a dedicated helper — every pattern that has a dedicated helper (averaging, rate of change, thresholds, time-of-day, scheduling, any-on/all-on) should go through that helper first.
 
 ---
 

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -6,19 +6,19 @@ This document covers Home Assistant's built-in helpers and integrations that sho
 1. [How Helpers Are Created](#how-helpers-are-created)
 2. [Menu-Based Helpers](#menu-based-helpers)
 3. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
-2. [Rate and Change](#rate-and-change) - derivative, threshold, trend
-3. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
-4. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
-5. [Counting and Timing](#counting-and-timing) - counter, timer
-6. [Scheduling](#scheduling) - schedule, time of day (tod)
-7. [Entity Grouping](#entity-grouping) - group, binary sensor groups
-8. [Probabilistic Inference](#probabilistic-inference) - bayesian
-9. [Data Smoothing](#data-smoothing) - filter
-10. [Random Values](#random-values) - random
-11. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
-12. [Domain Conversion](#domain-conversion) - switch_as_x
-13. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
-14. [Decision Matrix](#decision-matrix) - which helper for which need
+4. [Rate and Change](#rate-and-change) - derivative, threshold, trend
+5. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
+6. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
+7. [Counting and Timing](#counting-and-timing) - counter, timer
+8. [Scheduling](#scheduling) - schedule, time of day (tod)
+9. [Entity Grouping](#entity-grouping) - group, binary sensor groups
+10. [Probabilistic Inference](#probabilistic-inference) - bayesian
+11. [Data Smoothing](#data-smoothing) - filter
+12. [Random Values](#random-values) - random
+13. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
+14. [Domain Conversion](#domain-conversion) - switch_as_x
+15. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
+16. [Decision Matrix](#decision-matrix) - which helper for which need
 
 ## How Helpers Are Created
 

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -58,6 +58,13 @@ Additional requirements beyond the universal workflow:
 **Device-sibling discovery (Step 1):**
 HA devices bundle multiple entities. A smart plug might expose `switch.*`, `sensor.*_energy`, and `update.*`. A multi-sensor exposes motion, temperature, illuminance, and battery entities. Rename all siblings to match.
 
+> **One device entry per integration (2026.8+).** HA used to merge a physical device set up
+> through two integrations into a single device entry; each integration now keeps its own,
+> and previously-merged devices were split automatically on upgrade. So a single device
+> query can return only *part* of a physical device's entities — a bulb reachable over both
+> Matter and its vendor integration appears twice. Search by the shared name or identifier,
+> not by one device entry, before concluding you have found every sibling.
+
 Example — renaming a smart plug's entities from manufacturer defaults to room-based names:
 
 | Domain | Old entity ID | New entity ID |

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -255,8 +255,16 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
        sub = lambda m: (m.group(1) or "") + new_id   # keep the `states.` prefix
        if isinstance(obj, str):  return pat.sub(sub, obj)
        if isinstance(obj, list): return [_replace_ids(i, old_id, new_id, pat) for i in obj]
-       if isinstance(obj, dict): return {_replace_ids(k, old_id, new_id, pat): _replace_ids(v, old_id, new_id, pat)
-                                         for k, v in obj.items()}
+       if isinstance(obj, dict):
+           out = {}
+           for k, v in obj.items():
+               nk = _replace_ids(k, old_id, new_id, pat)
+               # Both ids present as keys (scene entity maps, card entity dicts)
+               # would silently collapse into one and drop the other's settings.
+               if nk in out:
+                   raise ValueError(f"rename collides on key {nk!r}; resolve by hand")
+               out[nk] = _replace_ids(v, old_id, new_id, pat)
+           return out
        return obj
 
    pat = entity_pattern("old.entity_id")          # reuse this in step 4

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -242,21 +242,25 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
 
 2. Replace entity IDs (Python — JSON-aware, boundary-safe):
    import re
-   def _replace_ids(obj, old_id, new_id, _pat=None):
-       # Substitutes *within* strings, so `states('x')` / `state_attr('x')` and
-       # `states.<domain>.<object>` object notation are all caught.
-       # First branch: lookarounds stop `sensor.old` matching `sensor.old_backup`.
-       # Second branch: after `states.`, only a word char may not follow — a dot
-       # there is attribute access (`.state`), since an entity_id has one dot.
-       pat = _pat or re.compile(
-           rf"(?<![\w.]){re.escape(old_id)}(?![\w.])"
-           rf"|(?<=states\.){re.escape(old_id)}(?![\w])")
-       if isinstance(obj, str):  return pat.sub(new_id, obj)
+   def entity_pattern(old_id):
+       # Matches `sensor.x` as a value, and `states.sensor.x` object notation.
+       # `(?<![\w.])` before BOTH branches stops `sensor.x` matching inside
+       # `sensor.x_backup` / `binary_sensor.x`, and stops the `states.` branch
+       # firing on a lookalike prefix such as `other_states.sensor.x`.
+       e = re.escape(old_id)
+       return re.compile(rf"(?<![\w.])(states\.){e}(?![\w])|(?<![\w.]){e}(?![\w.])")
+
+   def _replace_ids(obj, old_id, new_id, pat=None):
+       pat = pat or entity_pattern(old_id)
+       sub = lambda m: (m.group(1) or "") + new_id   # keep the `states.` prefix
+       if isinstance(obj, str):  return pat.sub(sub, obj)
        if isinstance(obj, list): return [_replace_ids(i, old_id, new_id, pat) for i in obj]
        if isinstance(obj, dict): return {_replace_ids(k, old_id, new_id, pat): _replace_ids(v, old_id, new_id, pat)
                                          for k, v in obj.items()}
        return obj
-   new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
+
+   pat = entity_pattern("old.entity_id")          # reuse this in step 4
+   new_config = _replace_ids(config, "old.entity_id", "new.entity_id", pat)
    # An exact whole-string match (obj == old_id) is NOT enough: it silently skips
    # every reference inside a Markdown card's Jinja ({{ states('sensor.old') }}),
    # which Step 2 explicitly tells you to search for. Plain string replace over
@@ -268,7 +272,8 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
    → takes effect immediately, no restart required
 
 4. Verify against the WRITTEN config, not the source you edited:
-   re-read via `lovelace/config` and re-run `pat.search()` over the serialized
+   re-read via `lovelace/config` and run `pat.search()` (the same compiled
+   pattern from step 2) over the serialized
    result — reuse the same boundary-aware pattern, not a plain substring test.
    A substring test reports `sensor.old_backup` as a stale `sensor.old`, and
    Step 5.4 then tells you to roll back a rename that actually succeeded.

--- a/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -4,6 +4,15 @@ Follow this workflow whenever you modify existing Home Assistant configuration: 
 
 **Core rule:** Search all consumers BEFORE changing anything. Verify zero stale references AFTER.
 
+## Table of Contents
+1. [Universal Workflow](#universal-workflow)
+2. [Entity Renames](#entity-renames)
+3. [Helper Replacements](#helper-replacements)
+4. [Trigger Restructuring](#trigger-restructuring)
+5. [Config-Entry-Groups](#config-entry-groups)
+6. [Config-Entry Data — Blind Spots for entity registry renames](#config-entry-data--blind-spots-for-entity-registry-renames)
+7. [Storage-Mode-Dashboards (`.storage/lovelace.*`)](#storage-mode-dashboards-storagelovelace)
+
 ---
 
 ## Universal Workflow
@@ -212,7 +221,7 @@ Iterate the returned entries and check `data` and `options` fields for the old e
 
 For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
 
-For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename. This is the one operation in this guide that a fetch-before-write rollback cannot undo, so treat the rename as irreversible and take a full backup first — see `references/backups.md#when-a-full-backup-earns-its-cost`.
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename. This is the one operation in this guide that a fetch-before-write rollback cannot undo, so treat the rename as irreversible and take a full backup first — see [backups #when-a-full-backup-earns-its-cost](backups.md#when-a-full-backup-earns-its-cost).
 
 ---
 
@@ -232,19 +241,39 @@ Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save
    → returns full dashboard config (JSON)
 
 2. Replace entity IDs (Python — JSON-aware, boundary-safe):
-   def _replace_ids(obj, old_id, new_id):
-       if isinstance(obj, str): return new_id if obj == old_id else obj
-       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id) for i in obj]
-       if isinstance(obj, dict): return {(new_id if k == old_id else k): _replace_ids(v, old_id, new_id) for k, v in obj.items()}
+   import re
+   def _replace_ids(obj, old_id, new_id, _pat=None):
+       # Substitutes *within* strings, so `states('x')` / `state_attr('x')` and
+       # `states.<domain>.<object>` object notation are all caught.
+       # First branch: lookarounds stop `sensor.old` matching `sensor.old_backup`.
+       # Second branch: after `states.`, only a word char may not follow — a dot
+       # there is attribute access (`.state`), since an entity_id has one dot.
+       pat = _pat or re.compile(
+           rf"(?<![\w.]){re.escape(old_id)}(?![\w.])"
+           rf"|(?<=states\.){re.escape(old_id)}(?![\w])")
+       if isinstance(obj, str):  return pat.sub(new_id, obj)
+       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id, pat) for i in obj]
+       if isinstance(obj, dict): return {_replace_ids(k, old_id, new_id, pat): _replace_ids(v, old_id, new_id, pat)
+                                         for k, v in obj.items()}
        return obj
    new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
-   # Note: string replace on json.dumps() is not boundary-safe — it matches entity IDs
-   # that appear as JSON keys or as substrings of other strings in the serialized output.
+   # An exact whole-string match (obj == old_id) is NOT enough: it silently skips
+   # every reference inside a Markdown card's Jinja ({{ states('sensor.old') }}),
+   # which Step 2 explicitly tells you to search for. Plain string replace over
+   # json.dumps() is the opposite failure — it has no boundaries at all.
 
 3. Write dashboard config:
    WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
    Note: use `"url_path": null` for the default (Overview) dashboard; use the string path for custom dashboards.
    → takes effect immediately, no restart required
+
+4. Verify against the WRITTEN config, not the source you edited:
+   re-read via `lovelace/config` and re-run `pat.search()` over the serialized
+   result — reuse the same boundary-aware pattern, not a plain substring test.
+   A substring test reports `sensor.old_backup` as a stale `sensor.old`, and
+   Step 5.4 then tells you to roll back a rename that actually succeeded.
+   Verifying the object you built in memory proves nothing about what the
+   dashboard now holds.
 ```
 
 

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -23,9 +23,9 @@ This document covers when templates ARE the right choice in Home Assistant, and 
 
 Templates are the RIGHT choice when:
 
-### 1. Dynamic Service Data
+### 1. Dynamic Action Data
 
-You need to pass dynamic values to service calls based on entity states or trigger context.
+You need to pass dynamic values to actions based on entity states or trigger context.
 
 ```yaml
 actions:
@@ -174,7 +174,7 @@ Do NOT use templates when a native alternative exists:
 | Template binary sensor with threshold | `threshold` helper |
 | Template sensor averaging over time | `statistics` helper |
 
-See `automation-patterns.md` and `helper-selection.md` for comprehensive alternatives.
+See [automation-patterns](automation-patterns.md) and [helper-selection](helper-selection.md) for comprehensive alternatives.
 
 ---
 
@@ -285,7 +285,7 @@ not in separate blocks per entity. Trigger-based blocks (with their own `trigger
 must be separate regardless of entity type, since each block defines its own trigger context:
 
 ```yaml
-# CORRECT — state-based sensors: one block, multiple entries:
+# GOOD — state-based sensors: one block, multiple entries:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -295,7 +295,7 @@ template:
         unique_id: motion_room_b
         state: "{{ ... }}"
 
-# AVOID — state-based sensors split across separate blocks:
+# BAD — state-based sensors split across separate blocks:
 template:
   - binary_sensor:
       - name: "Motion Room A"
@@ -634,7 +634,7 @@ The `.jinja` file requires filesystem access to the config directory — there i
 | Create `config/custom_templates/` | HA does not create it; a missing directory is not an error, it just yields no macros |
 | Add a `*.jinja` file | Subdirectories are scanned too; only the `.jinja` extension is loaded |
 | Import by path relative to `custom_templates/` | `battery.jinja`, or `sensors/battery.jinja` for a file in a subdirectory |
-| Call `homeassistant.reload_custom_templates` | Admin service, no restart. Required after every edit — HA holds the sources in memory. `homeassistant.reload_all` includes it |
+| Call `homeassistant.reload_custom_templates` | Admin action, no restart. Required after every edit — HA holds the sources in memory. `homeassistant.reload_all` includes it |
 
 
 ```jinja

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -430,9 +430,27 @@ Always use `states()` function, not `states.sensor.x.state`:
 
 ### Attribute Access with Default
 
+`state_attr` returns `None` when the attribute is absent (a light that is off has no
+`brightness`) or the entity does not exist. Jinja's `default` substitutes only for an
+**undefined** name, and `None` is defined — so it passes straight through and the template
+renders the string `None`.
+
 ```yaml
+# BAD - renders "None" while the light is off
 {{ state_attr('light.bedroom', 'brightness') | default(0) }}
+
+# GOOD - the second argument makes default replace any falsy value, None included
+{{ state_attr('light.bedroom', 'brightness') | default(0, true) }}
+
+# GOOD - a type filter's default covers None and converts in one step
+{{ state_attr('light.bedroom', 'brightness') | int(0) }}
 ```
+
+The same trap applies to `| default(...)` after anything that can yield `None`
+(`state_attr`, `.get()`, an attribute that exists but is null) — pass `true` or use
+`int()`/`float()`. Both replace *any* falsy value though, so a real `0`, `False` or `''`
+becomes the default too. Where those are meaningful values, test explicitly instead — see
+[Handle None Attributes](#handle-none-attributes).
 
 ### Time Since State Change
 
@@ -480,12 +498,18 @@ Always use `states()` function, not `states.sensor.x.state`:
 {{ states('sensor.x') | float(default=0) }}
 {{ states('sensor.x') | int(default=-1) }}
 
-# For attribute access
-{{ state_attr('light.x', 'brightness') | default(100) }}
+# For attribute access - `true` is required, because state_attr returns None
+{{ state_attr('light.x', 'brightness') | default(100, true) }}
 
-# For entire template failures
-{{ states('sensor.missing') | default('Unknown', true) }}
+# For a missing or unavailable entity - test it; no default filter will catch it
+{{ states('sensor.missing') if has_value('sensor.missing') else 'Unknown' }}
 ```
+
+**A default filter cannot rescue a missing entity.** `states()` returns the *string*
+`"unknown"` for an entity that does not exist (and `"unavailable"` for one that is
+offline). Both are non-empty strings, so both are truthy: `| default('Unknown', true)`
+leaves them untouched and the template renders `unknown`. `has_value()` is the test that
+covers missing, `unknown`, and `unavailable` in one call.
 
 ### Availability Template
 
@@ -716,7 +740,7 @@ For a real return value, give the macro a `returns` argument and convert it with
 | `float(default)` | Convert to float |
 | `int(default)` | Convert to int |
 | `round(precision)` | Round number |
-| `default(value)` | Provide fallback |
+| `default(value, true)` | Fallback; the `true` is what catches `None` |
 | `timestamp_custom(format)` | Format timestamp |
 | `from_json` | Parse JSON string |
 | `to_json` | Convert to JSON string |

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -448,8 +448,10 @@ renders the string `None`.
 
 The same trap applies to `| default(...)` after anything that can yield `None`
 (`state_attr`, `.get()`, an attribute that exists but is null) — pass `true` or use
-`int()`/`float()`. Both replace *any* falsy value though, so a real `0`, `False` or `''`
-becomes the default too. Where those are meaningful values, test explicitly instead — see
+`int()`/`float()` — but they are not equivalent. `default(x, true)` replaces **any** falsy
+value, so a real `0`, `False` or `''` becomes the default too; `int(x)`/`float(x)` fall back
+only when the **conversion fails**, so a real `0` stays `0` and `False` converts to `0`.
+Where a falsy value is meaningful, use the conversion filter, or test explicitly — see
 [Handle None Attributes](#handle-none-attributes).
 
 ### Time Since State Change
@@ -509,7 +511,9 @@ becomes the default too. Where those are meaningful values, test explicitly inst
 `"unknown"` for an entity that does not exist (and `"unavailable"` for one that is
 offline). Both are non-empty strings, so both are truthy: `| default('Unknown', true)`
 leaves them untouched and the template renders `unknown`. `has_value()` is the test that
-covers missing, `unknown`, and `unavailable` in one call.
+covers missing, `unknown`, and `unavailable` in one call — in a full template. Limited
+template contexts (a blueprint's `trigger_variables:`, `enabled:`) have no `states()` or
+`has_value()`; see [blueprint-guide #referencing-inputs-input-and-templating](blueprint-guide.md#referencing-inputs-input-and-templating).
 
 ### Availability Template
 

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -25,4 +25,11 @@ For sending notifications, prefer config-flow notify integrations (Mobile App, T
 | `sensor` / `binary_sensor` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `sensor:` (or `binary_sensor:`) key with a block sequence of `- platform: <name>` entries — for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
 | `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `switch:` / `light:` / etc. key with a block sequence of `- platform: <name>` entries — only for platforms that have no config flow. Check the integration's docs before assuming YAML is required |
 
-Confirm with the user before triggering `homeassistant.restart` — it briefly interrupts all automations and integrations.
+## Post-Edit Actions
+
+A YAML edit changes nothing until the integration re-reads the file. Which action applies is the second column above:
+
+- **`<domain>.reload`** — where the integration offers one. It reloads that domain only; nothing else is interrupted.
+- **`homeassistant.restart`** — the fallback for platform-style YAML, which has no reload action. **Confirm with the user first:** it briefly interrupts every automation and integration, not just the one you edited.
+
+Run `homeassistant.check_config` first. `homeassistant.restart` validates the config itself and refuses to restart when it fails, so the risk isn't a broken instance — it's that a reload silently leaves the old config running, or that you spend the user's restart to discover a typo.


### PR DESCRIPTION
## What does this PR do?

Fixes correctness bugs in the skill, brings it up to Home Assistant 2026.8, and makes cross-file references machine-checkable so this class of drift is caught by CI rather than by a reader months later.

**Correctness.** Two Jinja patterns were wrong as written and are copied verbatim by agents: `state_attr(x, y) | default(0)` renders `None` (`state_attr` returns `None`, and Jinja's `default` substitutes only for an *undefined* name), and `states('sensor.missing') | default('Unknown', true)` renders `unknown` (`states()` returns the truthy *string* `"unknown"`). Both verified against core 2026.8.3. `_replace_ids` in `safe-refactoring.md` silently skipped `{{ states.sensor.x.state }}` object notation while its comment claimed otherwise, and its verification step used a substring match that reports `sensor.x_backup` as a stale `sensor.x` — driving a rollback of a rename that succeeded.

**2026.8.** Developer Tools is now Tools; the moon and vibration trigger/condition families are new in 2026.8 (the whole `vibration` component 404s at 2026.7.4, so neither may be emitted for a 2026.7 instance); new HA OS installs no longer default to port 8123; the device registry no longer merges one physical device across two integrations; template fan/cover/device_tracker entities restore state.

**Doctrine.** `device-control.md` still closed with "always prefer `state` triggers" — the pattern SKILL.md's own anti-pattern table now flags in favour of purpose-specific triggers with an area target. Button/remote guidance is generalised beyond Zigbee: where an integration exposes an `event.*` entity, `event.received` is entity-based and survives re-adds. ZHA has no event platform (verified) and keeps `zha_event`; Z2M's event entities are experimental and off by default.

**Cross-references are now markdown links.** Inside backticks they were invisible to every standard tool, so nothing had ever validated them. Dropping the "Key sections" column — 77 anchors of always-loaded context that largely duplicated tables of contents shipped inside the target files — more than paid for the added syntax: **SKILL.md is 2,241 characters smaller**. `device-control.md` and `safe-refactoring.md` gained the tables of contents they lacked.

**`metadata.version` is now a quoted string.** The spec requires metadata values to be strings; an unquoted integer makes strict clients fail to parse `SKILL.md` outright. `skills-ref` misses this because its check is a Python type annotation with no runtime enforcement — it reports "Valid skill" on a tree `agnix` rejects with `AS-016`.

### CI

- **lychee** — PR job runs `--offline --include-fragments` (local links and `#anchors`, no network, deterministic); external URLs move to a weekly job so upstream rot never fails an unrelated PR. Mutation-tested: breaking an anchor, a path, or writing `references/x.md` from inside `references/` each exits non-zero.
- **agnix** — second opinion on spec conformance, scoped to `skills/` and non-strict. Would have caught `AS-016` on the PR that introduced it.

Both are additive; `skills-ref` remains the conformance floor.

### Reviewed

Six independent review agents across two rounds. They caught real defects, including two I introduced: the object-notation gap above, and a claim that vibration triggers pre-dated 2026.8 — the release blog's *"Vibration now has conditions to match its triggers"* implies it, but the component 404s at the prior tag. Guidance based on the blog would have told 2026.7 users to emit a trigger that does not exist.

### Known gap

Nothing detects a reference file that nothing links to — lychee has no concept of an unreferenced file, and `skills-ref` passes an orphan. Recorded as a review checklist item in `CONTRIBUTING.md` rather than papered over.

## Checklist

- [x] Tested with real scenarios (if changing skill content)
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)

<sub>Reference paths in the README table are now links, so CI catches drift there too — one entry had already gone stale.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded Home Assistant guidance for event-based triggers, actions, backups, blueprints, dashboards, templates, helpers, and safe refactoring.
  - Added guidance for newer Home Assistant releases, migration scenarios, configuration validation, and clearer terminology.
  - Improved navigation with linked references, updated contents, and authoring instructions.
  - Clarified dashboard visual inspection and instance URL handling.

- **Validation**
  - Added automated link and skill-quality checks.
  - Expanded evaluations for automation and configuration scenarios.
  - Improved metadata version formatting consistency and validation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->