### PR TITLE
fix(best-practices): show helper config-flow fields, not YAML platform blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,20 @@ To validate locally:
 uvx --from skills-ref agentskills validate skills/<skill-name>
 ```
 
-`.github/workflows/links.yml` runs lychee over the repo's markdown, dot-directories
-excluded: local file links and their `#anchors` (`--offline --include-fragments`) on PRs
-that touch `.md`/`.yaml`, and external URLs weekly. It cannot see references written as
-inline code, and nothing checks that every reference file is still routed from SKILL.md —
-that stays a review item.
+Two more checks gate a merge, as release binaries pinned in `.github/workflows/` — install
+those versions (lychee's release tag is `lychee-vX.Y.Z`, not `vX.Y.Z`):
+
+```bash
+agnix skills/ --target claude-code                              # spec conformance
+lychee --offline --include-fragments --no-progress './**/*.md'  # local links + #anchors
+```
+
+agnix catches what skills-ref's unenforced `metadata: dict[str, str]` annotation lets pass —
+e.g. an unquoted integer version, which strict clients refuse. In CI (`links.yml`) lychee runs
+that same local check on PRs touching `.md`/`.yaml`, plus external URLs weekly, dot-directories
+excluded; it cannot see references written as inline code. Two things nothing checks, so both
+stay review items: that every reference file is still routed from SKILL.md, and that
+`references/examples.yaml` still parses.
 
 ## Reviewing Skill PRs
 
@@ -63,3 +72,5 @@ that stays a review item.
 - UI renames, terminology, and default changes appear only in release blog posts, not core source: `source/_posts/<date>-release-<version>.markdown` in the docs repo (e.g. `2026-08-05-release-20268.markdown`). Use `gh api` — plain `curl` is sandboxed here and returns empty
 - **The blog says *what* changed, not *which version* it landed in.** Its prose often implies a feature pre-existed ("X now has conditions to match its triggers") when the whole component is new. Date a feature by fetching its path at the *previous* tag — a 404 at the previous tag that exists at the current one means the whole thing is new
 - Community PRs come from forks: base-repo `?ref=<pr-branch>` 404s; get the fork with `gh pr view <pr> --json headRepository` and fetch files from there
+- Helper claims need **both** `config_flow.py` (flow submission) and the platform file's `PLATFORM_SCHEMA` (YAML) — they diverge in key names, value types, and which keys exist. Traps: `vol.Required(` usually puts the `CONF_*` on the *next* line, so grep drops fields and mis-attributes Required/Optional; resolve `CONF_*` to its string (`CONF_ROUND_DIGITS` is `"round"` in derivative, `"round_digits"` in min_max); `options_flow`-only fields are rejected at creation
+- Verifying a claim confirms what it says, not whether it over-generalizes. Add a pass that tries to disprove ("which helpers does this NOT hold for?"), mechanically where possible — e.g. diff the two schemas' key sets in a script

--- a/skills/home-assistant-best-practices/SKILL.md
+++ b/skills/home-assistant-best-practices/SKILL.md
@@ -61,9 +61,13 @@ Before creating a template sensor, check [helper-selection](references/helper-se
 - Consumption tracking → `utility_meter` helper
 
 **If no built-in helper fits, use a Template Helper — not YAML.**
-Create it via the HA config flow (MCP tool or API) or via the UI:
-Settings → Devices & Services → Helpers → Create Helper → Template.
-Only write `template:` YAML if explicitly requested or if neither path is available.
+Create it via the HA config flow (programmatically or in the UI:
+Settings → Devices & Services → Helpers → Create Helper → Template). A flow-created helper
+is UI-editable; a `template:` YAML entry needs a `template.reload` and is not.
+
+Write `template:` YAML when the user asks for it, when neither path is available, or when
+the config needs a key the flow has no field for — trigger-based templates and `attributes:`
+are the common ones. Then use managed YAML editing ([yaml-only-integrations](references/yaml-only-integrations.md)), not a hand-edit.
 
 ### 3. Select correct automation mode
 Default `single` mode is often wrong. See [automation-patterns #automation-modes](references/automation-patterns.md#automation-modes).
@@ -103,7 +107,7 @@ See [device-control #buttonremote-patterns](references/device-control.md#buttonr
 | Renaming entity IDs without impact analysis | Follow [safe-refactoring](references/safe-refactoring.md) workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | [safe-refactoring #entity-renames](references/safe-refactoring.md#entity-renames) |
 | Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | [safe-refactoring #config-entry-groups](references/safe-refactoring.md#config-entry-groups) |
 | Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | [safe-refactoring #config-entry-data--blind-spots-for-entity-registry-renames](references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames) |
-| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | [template-guidelines](references/template-guidelines.md) |
+| `template:` sensor/binary sensor in YAML | Template Helper via the config flow | A flow helper reloads in place and stays UI-editable; a `template:` entry needs a config reload and does not. Exceptions are real — trigger-based templates and `attributes:` have no flow field | [helper-selection #template-helpers](references/helper-selection.md#template-helpers) |
 | Editing `.storage/` files or other HA internal state directly | Use the HA REST/WebSocket API to manage state and config entries | `.storage/` files are HA's internal state database; direct edits bypass validation, risk corruption, and can be silently overwritten by HA | — |
 | Writing raw YAML to `configuration.yaml` by hand for YAML-only integrations | Use managed YAML config editing with backup and validation | Unmanaged writes risk syntax errors, have no backup, and skip `check_config` — managed editing provides all three | [yaml-only-integrations](references/yaml-only-integrations.md) |
 | Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | [automation-patterns](references/automation-patterns.md), [examples.yaml](references/examples.yaml) |

--- a/skills/home-assistant-best-practices/evals/evals.json
+++ b/skills/home-assistant-best-practices/evals/evals.json
@@ -113,7 +113,7 @@
       "id": 7,
       "eval_name": "rename-entity-impact-analysis",
       "prompt": "rename sensor.shellyplug_s_a1b2c3_power to sensor.office_heater_power, it's driving me nuts seeing the manufacturer name on my energy dashboard",
-      "expected_output": "Searches consumers BEFORE renaming \u2014 automations, scripts, scenes, dashboards (including storage-mode Lovelace and badges), and Config Entry data/options \u2014 then renames and verifies zero stale references.",
+      "expected_output": "Searches consumers BEFORE renaming — automations, scripts, scenes, dashboards (including storage-mode Lovelace and badges), and Config Entry data/options — then renames and verifies zero stale references.",
       "assertions": [
         {
           "id": "searches_before_renaming",
@@ -213,7 +213,7 @@
         },
         {
           "id": "notes_direct_delete_has_no_guard",
-          "description": "Response notes that HA's retention cleanup protects the last remaining backup but a direct delete of a specific backup has no such guard \u2014 the caution has to come from the caller"
+          "description": "Response notes that HA's retention cleanup protects the last remaining backup but a direct delete of a specific backup has no such guard — the caution has to come from the caller"
         }
       ]
     },
@@ -258,6 +258,50 @@
         {
           "id": "addresses_the_maintenance_ask",
           "description": "Response explains that new sensors added to the area are picked up without editing the automation"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "eval_name": "template-attributes-yaml-exception",
+      "prompt": "I want a sensor that shows which motion sensor triggered last, with the entity_id and timestamp as extra attributes",
+      "expected_output": "Recognizes this needs a trigger-based template with attributes:, which the Template Helper config flow cannot express, and routes to managed YAML editing rather than refusing or forcing it into the flow",
+      "assertions": [
+        {
+          "id": "identifies_trigger_based",
+          "description": "Response uses a trigger-based template (triggers: on the template block) because the value must be captured when the trigger fires, not recomputed from current state"
+        },
+        {
+          "id": "names_yaml_as_correct_path",
+          "description": "Response states that trigger-based templates and attributes: have no Template Helper config-flow field, so YAML is the correct path here — it does not claim the helper can do it"
+        },
+        {
+          "id": "managed_yaml_not_handedit",
+          "description": "Response reaches YAML through managed config editing (backup, validation, check_config) or the appropriate reload, rather than instructing an unchecked hand-edit of configuration.yaml"
+        },
+        {
+          "id": "no_min_max_confusion",
+          "description": "Response does not suggest a min_max or statistics helper, which cannot report which entity changed"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "eval_name": "helper-flow-fields-not-platform-yaml",
+      "prompt": "Set up a binary sensor that turns on when the outdoor temperature goes above 25 degrees, with a bit of buffer so it doesn't flap",
+      "expected_output": "Recommends the threshold helper created through the config flow, supplying entity_id/upper/hysteresis as flow fields, not a binary_sensor: - platform: threshold block to paste into configuration.yaml",
+      "assertions": [
+        {
+          "id": "recommends_threshold_helper",
+          "description": "Response recommends the threshold helper rather than a template binary sensor"
+        },
+        {
+          "id": "uses_hysteresis",
+          "description": "Response uses the hysteresis field to address the flapping concern"
+        },
+        {
+          "id": "no_platform_wrapper",
+          "description": "Response does not present 'binary_sensor:' with '- platform: threshold' as the thing to write; the config is given as the helper's fields (config flow), or if YAML is shown it is labeled as config shape rather than a file to hand-edit"
         }
       ]
     }

--- a/skills/home-assistant-best-practices/references/appdaemon.md
+++ b/skills/home-assistant-best-practices/references/appdaemon.md
@@ -1,5 +1,7 @@
 # AppDaemon Best Practices
 
+> **AppDaemon apps are files by design** — Python modules plus `apps.yaml`, read from AppDaemon's own config directory rather than HA's config API. The YAML here is genuine file content. Everything HA-side these apps create (helpers, automations) still goes through the HA config API.
+
 AppDaemon is the right tool when native HA automations reach their limits: complex
 multi-step logic, stateful workflows, external API orchestration, or anything that
 benefits from a real programming language. It is **not** a replacement for HA

--- a/skills/home-assistant-best-practices/references/blueprint-guide.md
+++ b/skills/home-assistant-best-practices/references/blueprint-guide.md
@@ -1,5 +1,7 @@
 # Blueprints
 
+> **A blueprint is a file, but you still should not hand-write it.** It lives at `config/blueprints/<domain>/<author>/<name>.yaml`, and the WebSocket API authors it for you: `blueprint/save` takes `{domain, path, yaml, source_url?}`, validates against the blueprint schema, and writes the file — with `blueprint/import`, `blueprint/list`, `blueprint/delete`, and `blueprint/substitute` alongside it. Prefer that over an unchecked file write. The automations *created from* a blueprint are ordinary config-API objects.
+
 A **blueprint is a reusable, parameterized automation/script/template** — a skeleton whose device- and entity-specific parts are replaced by user-provided **inputs**. Author a blueprint only when a pattern will be instantiated more than once or shared/distributed. A one-off automation should stay a plain automation; don't blueprint what you'll use once.
 
 ## Table of Contents

--- a/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -1,5 +1,7 @@
 # Dashboard Guide
 
+> **The YAML below shows config shape, not a file to hand-edit.** Storage-mode dashboards live in `.storage/` and are written through the Lovelace WebSocket API (`lovelace/config/save`) — never by editing the file. See [safe-refactoring #storage-mode-dashboards](safe-refactoring.md#storage-mode-dashboards-storagelovelace).
+
 Patterns and decisions for designing Home Assistant Lovelace dashboards.
 
 ## Table of Contents

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -1,5 +1,7 @@
 # Device Control Patterns
 
+> **The YAML below shows config shape, not a file to hand-edit.** Create and update these through the HA config API, which validates the config and needs no restart. Actions and triggers are submitted as part of an automation or script object.
+
 Best practices for controlling devices, triggering from buttons and remotes, and structuring actions.
 
 > **Check for a purpose-specific trigger first.** Since 2026.7 the default building block is

--- a/skills/home-assistant-best-practices/references/examples.yaml
+++ b/skills/home-assistant-best-practices/references/examples.yaml
@@ -3,6 +3,13 @@
 # =============================================================================
 # Each example demonstrates MULTIPLE best practices working together.
 # For individual patterns, see the corresponding reference file.
+#
+# SHAPE: examples 1-6 are each one automation/script OBJECT, as submitted to the
+# HA config API — not fragments of configuration.yaml. There is deliberately no
+# `automation:` / `script:` file wrapper: creating these through the config API
+# validates the config and needs no file edit or restart. Example 7 (MQTT) is the
+# deliberate exception and IS file shape; it says so inline. Examples are
+# separated by `---` so the file parses as a multi-document stream.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -15,47 +22,47 @@
 # The state trigger is kept
 # here because wait_for_trigger below reuses the same entity.
 
-automation:
-  - id: motion_light_hallway
-    alias: "Hallway Motion Light"
-    description: "Turn on hallway light when motion detected, auto-off after 3 minutes"
-    mode: restart  # Re-trigger resets the timer
+---
+id: motion_light_hallway
+alias: "Hallway Motion Light"
+description: "Turn on hallway light when motion detected, auto-off after 3 minutes"
+mode: restart  # Re-trigger resets the timer
 
-    triggers:
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.hallway_motion
+    to: "on"
+
+conditions:
+  # Native time condition - no template needed
+  - condition: time
+    after: "06:00:00"
+    before: "23:00:00"
+
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.hallway
+    data:
+      brightness_pct: 80
+      transition: 1
+
+  # wait_for_trigger - event-driven, waits for the change
+  - wait_for_trigger:
       - trigger: state
         entity_id: binary_sensor.hallway_motion
-        to: "on"
+        to: "off"
+        for:
+          minutes: 3
+    timeout:
+      minutes: 10
+    continue_on_timeout: true
 
-    conditions:
-      # Native time condition - no template needed
-      - condition: time
-        after: "06:00:00"
-        before: "23:00:00"
-
-    actions:
-      - action: light.turn_on
-        target:
-          entity_id: light.hallway
-        data:
-          brightness_pct: 80
-          transition: 1
-
-      # wait_for_trigger - event-driven, waits for the change
-      - wait_for_trigger:
-          - trigger: state
-            entity_id: binary_sensor.hallway_motion
-            to: "off"
-            for:
-              minutes: 3
-        timeout:
-          minutes: 10
-        continue_on_timeout: true
-
-      - action: light.turn_off
-        target:
-          entity_id: light.hallway
-        data:
-          transition: 3
+  - action: light.turn_off
+    target:
+      entity_id: light.hallway
+    data:
+      transition: 3
 
 
 # -----------------------------------------------------------------------------
@@ -64,60 +71,61 @@ automation:
 # Demonstrates: ZHA event trigger, device_ieee (persistent), trigger_id, choose
 # Best practice: Use device_ieee instead of device_id for ZHA
 
-  - id: bedroom_remote_control
-    alias: "Bedroom Remote Control"
-    description: "Handle single, double, and hold presses on ZHA button"
-    mode: single
+---
+id: bedroom_remote_control
+alias: "Bedroom Remote Control"
+description: "Handle single, double, and hold presses on ZHA button"
+mode: single
 
-    triggers:
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_ieee: "00:15:8d:00:07:26:f2:8a"  # Replace with your device
-          command: "single"
-        id: single_press
+triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"  # Replace with your device
+      command: "single"
+    id: single_press
 
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_ieee: "00:15:8d:00:07:26:f2:8a"
-          command: "double"
-        id: double_press
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"
+      command: "double"
+    id: double_press
 
-      - trigger: event
-        event_type: zha_event
-        event_data:
-          device_ieee: "00:15:8d:00:07:26:f2:8a"
-          command: "hold"
-        id: hold
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"
+      command: "hold"
+    id: hold
 
-    actions:
-      - choose:
-          - conditions:
-              - condition: trigger
-                id: single_press
-            sequence:
-              - action: light.toggle
-                target:
-                  entity_id: light.bedroom
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: single_press
+        sequence:
+          - action: light.toggle
+            target:
+              entity_id: light.bedroom
 
-          - conditions:
-              - condition: trigger
-                id: double_press
-            sequence:
-              - action: light.turn_on
-                target:
-                  area_id: bedroom
-                data:
-                  brightness_pct: 100
+      - conditions:
+          - condition: trigger
+            id: double_press
+        sequence:
+          - action: light.turn_on
+            target:
+              area_id: bedroom
+            data:
+              brightness_pct: 100
 
-          - conditions:
-              - condition: trigger
-                id: hold
-            sequence:
-              - action: light.turn_off
-                target:
-                  area_id: bedroom
+      - conditions:
+          - condition: trigger
+            id: hold
+        sequence:
+          - action: light.turn_off
+            target:
+              area_id: bedroom
 
 
 # -----------------------------------------------------------------------------
@@ -126,62 +134,68 @@ automation:
 # Demonstrates: queued mode, state condition with attribute, not condition, template message
 # Best practice: Use queued mode when order matters
 
-  - id: door_unlock_notification
-    alias: "Door Unlock Notification"
-    description: "Notify when door is unlocked, show who unlocked it"
-    mode: queued  # Process each unlock event in order
-    max: 10
+---
+id: door_unlock_notification
+alias: "Door Unlock Notification"
+description: "Notify when door is unlocked, show who unlocked it"
+mode: queued  # Process each unlock event in order
+max: 10
 
-    triggers:
-      - trigger: state
-        entity_id: lock.front_door
-        to: "unlocked"
+triggers:
+  - trigger: state
+    entity_id: lock.front_door
+    to: "unlocked"
 
+conditions:
+  # Native not + state condition with attribute check - no template
+  - condition: not
     conditions:
-      # Native not + state condition with attribute check - no template
-      - condition: not
-        conditions:
-          - condition: state
-            entity_id: lock.front_door
-            attribute: changed_by
-            state: "auto_unlock"
+      - condition: state
+        entity_id: lock.front_door
+        attribute: changed_by
+        state: "auto_unlock"
 
-    actions:
-      - action: notify.mobile_app_phone
-        data:
-          title: "Front Door Unlocked"
-          message: "Unlocked by {{ state_attr('lock.front_door', 'changed_by') }}"
-          data:
-            tag: "door-unlock"
+actions:
+  - action: notify.mobile_app_phone
+    data:
+      title: "Front Door Unlocked"
+      message: "Unlocked by {{ state_attr('lock.front_door', 'changed_by') }}"
+      data:
+        tag: "door-unlock"
 
 
 # -----------------------------------------------------------------------------
 # EXAMPLE 4: Parallel Mode for Per-Entity Actions
 # -----------------------------------------------------------------------------
-# Demonstrates: parallel mode, multi-entity trigger, trigger variable in template target
-# Best practice: Use parallel mode when actions are independent per-entity
+# Demonstrates: parallel mode, multi-entity trigger, area-derived target
+# Best practice: Use parallel mode when actions are independent per-entity;
+# derive the target from the AREA REGISTRY, not from entity-id string surgery
 
-  - id: window_open_climate_off
-    alias: "Turn Off Climate When Window Opens"
-    description: "Turn off climate in room when window is opened"
-    mode: parallel  # Handle multiple windows independently
-    max: 10
+---
+id: window_open_climate_off
+alias: "Turn Off Climate When Window Opens"
+description: "Turn off climate in room when window is opened"
+mode: parallel  # Handle multiple windows independently
+max: 10
 
-    triggers:
-      - trigger: state
-        entity_id:
-          - binary_sensor.bedroom_window
-          - binary_sensor.living_room_window
-          - binary_sensor.kitchen_window
-        to: "on"
+# Since 2026.7 a purpose-specific `window.opened` trigger with a floor/label
+# `target:` replaces this hardcoded list and picks up new windows automatically.
+# Confirm which trigger variables that trigger exposes before porting the
+# `area_id(trigger.entity_id)` action below to it.
+triggers:
+  - trigger: state
+    entity_id:
+      - binary_sensor.bedroom_window
+      - binary_sensor.living_room_window
+      - binary_sensor.kitchen_window
+    to: "on"
 
-    actions:
-      # Use trigger variable to determine which room
-      - action: climate.turn_off
-        target:
-          entity_id: >
-            {% set room = trigger.entity_id.split('.')[1].replace('_window', '') %}
-            climate.{{ room }}
+actions:
+  # Resolve the room from the area registry — the window sensor and the climate
+  # entity only need to share an area, not a naming convention.
+  - action: climate.turn_off
+    target:
+      area_id: "{{ area_id(trigger.entity_id) }}"
 
 
 # -----------------------------------------------------------------------------
@@ -192,39 +206,40 @@ automation:
 # If the doorbell exposes an `event.*` entity, prefer `trigger: event.received` with
 # `options.event_type` over this state trigger — see device-control.md#buttonremote-patterns.
 
-  - id: doorbell_announcement
-    alias: "Doorbell Announcement"
-    description: "Announce doorbell with different messages based on time"
-    mode: single
+---
+id: doorbell_announcement
+alias: "Doorbell Announcement"
+description: "Announce doorbell with different messages based on time"
+mode: single
 
-    triggers:
-      - trigger: state
-        entity_id: binary_sensor.doorbell
-        to: "on"
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.doorbell
+    to: "on"
 
-    actions:
-      - if:
-          - condition: time
-            after: "22:00:00"
-            before: "08:00:00"
-        then:
-          # Quiet hours - just notification
-          - action: notify.mobile_app_phone
-            data:
-              title: "Doorbell"
-              message: "Someone is at the door"
-        else:
-          # Normal hours - announce and notification
-          - action: tts.speak
-            target:
-              entity_id: tts.google_say
-            data:
-              media_player_entity_id: media_player.living_room_speaker
-              message: "Someone is at the front door"
-          - action: notify.mobile_app_phone
-            data:
-              title: "Doorbell"
-              message: "Someone is at the door"
+actions:
+  - if:
+      - condition: time
+        after: "22:00:00"
+        before: "08:00:00"
+    then:
+      # Quiet hours - just notification
+      - action: notify.mobile_app_phone
+        data:
+          title: "Doorbell"
+          message: "Someone is at the door"
+    else:
+      # Normal hours - announce and notification
+      - action: tts.speak
+        target:
+          entity_id: tts.google_say
+        data:
+          media_player_entity_id: media_player.living_room_speaker
+          message: "Someone is at the front door"
+      - action: notify.mobile_app_phone
+        data:
+          title: "Doorbell"
+          message: "Someone is at the door"
 
 
 # -----------------------------------------------------------------------------
@@ -235,46 +250,46 @@ automation:
 # Best practice: Use the HA config API to create scripts programmatically
 # rather than generating YAML snippets for manual file editing
 
-script:
-  good_night:
-    alias: "Good Night"
-    description: "Turn off lights, lock doors, and set thermostat for sleeping"
-    icon: mdi:weather-night
-    mode: single
-    fields:
-      sleep_temp:
-        name: Sleep Temperature
-        description: "Target temperature for sleeping"
-        selector:
-          number:
-            min: 60
-            max: 75
-            unit_of_measurement: "°F"
-        default: 68
-    sequence:
-      - action: light.turn_off
-        target:
-          area_id:
-            - living_room
-            - kitchen
-            - bedroom
+---
+# object_id: good_night  (the key this script is stored under)
+alias: "Good Night"
+description: "Turn off lights, lock doors, and set thermostat for sleeping"
+icon: mdi:weather-night
+mode: single
+fields:
+  sleep_temp:
+    name: Sleep Temperature
+    description: "Target temperature for sleeping"
+    selector:
+      number:
+        min: 60
+        max: 75
+        unit_of_measurement: "°F"
+    default: 68
+sequence:
+  - action: light.turn_off
+    target:
+      area_id:
+        - living_room
+        - kitchen
+        - bedroom
 
-      - action: lock.lock
-        target:
-          entity_id:
-            - lock.front_door
-            - lock.back_door
+  - action: lock.lock
+    target:
+      entity_id:
+        - lock.front_door
+        - lock.back_door
 
-      - action: climate.set_temperature
-        target:
-          entity_id: climate.main
-        data:
-          temperature: "{{ sleep_temp }}"
-          hvac_mode: heat
+  - action: climate.set_temperature
+    target:
+      entity_id: climate.main
+    data:
+      temperature: "{{ sleep_temp }}"
+      hvac_mode: heat
 
-      - action: notify.mobile_app_phone
-        data:
-          message: "Good night! Lights off, doors locked, thermostat set to {{ sleep_temp }}°F."
+  - action: notify.mobile_app_phone
+    data:
+      message: "Good night! Lights off, doors locked, thermostat set to {{ sleep_temp }}°F."
 
 
 # -----------------------------------------------------------------------------
@@ -314,7 +329,10 @@ script:
 
 # APPROACH 3 (LEGACY FALLBACK): YAML in configuration.yaml
 # Only use if subentries don't support the entity platform yet, or if the
-# user explicitly requests YAML config.
+# user explicitly requests YAML config. Unlike the examples above, this one IS
+# file shape — write it with managed YAML editing (backup + check_config), then
+# reload the MQTT domain. See yaml-only-integrations.md.
+---
 mqtt:
   sensor:
     - name: "Outdoor Temperature"

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -1,31 +1,32 @@
 # Helper Selection Guide
 
-This document covers Home Assistant's built-in helpers and integrations that should be used instead of YAML template sensors or complex automations. When no dedicated helper covers your need, the **Template Helper** (created via the UI / config-entry flow, not YAML `template:`) is the right escape hatch — see [Template Helpers](#template-helpers).
+This document covers Home Assistant's built-in helpers and integrations that should be used instead of YAML template sensors or complex automations. When no dedicated helper covers your need, the **Template Helper** (created through the config flow, not YAML `template:`) is the right escape hatch — see [Template Helpers](#template-helpers).
 
 ## Table of Contents
 1. [How Helpers Are Created](#how-helpers-are-created)
 2. [Menu-Based Helpers](#menu-based-helpers)
-3. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
-4. [Rate and Change](#rate-and-change) - derivative, threshold, trend
-5. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
-6. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
-7. [Counting and Timing](#counting-and-timing) - counter, timer
-8. [Scheduling](#scheduling) - schedule, time of day (tod)
-9. [Entity Grouping](#entity-grouping) - group, binary sensor groups
-10. [Probabilistic Inference](#probabilistic-inference) - bayesian
-11. [Data Smoothing](#data-smoothing) - filter
-12. [Random Values](#random-values) - random
-13. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
-14. [Domain Conversion](#domain-conversion) - switch_as_x
-15. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
-16. [Decision Matrix](#decision-matrix) - which helper for which need
+3. [Reading the Examples in This File](#reading-the-examples-in-this-file) - config-flow fields vs. YAML platform shape
+4. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
+5. [Rate and Change](#rate-and-change) - derivative, threshold, trend
+6. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
+7. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
+8. [Counting and Timing](#counting-and-timing) - counter, timer
+9. [Scheduling](#scheduling) - schedule, time of day (tod)
+10. [Entity Grouping](#entity-grouping) - group, binary sensor groups
+11. [Probabilistic Inference](#probabilistic-inference) - bayesian
+12. [Data Smoothing](#data-smoothing) - filter
+13. [Random Values](#random-values) - random
+14. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
+15. [Domain Conversion](#domain-conversion) - switch_as_x
+16. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
+17. [Decision Matrix](#decision-matrix) - which helper for which need
 
 ## How Helpers Are Created
 
 Helpers reach Home Assistant through two different creation mechanisms — which one a helper uses determines whether you submit flat fields in a single step or step through a config flow:
 
-- **Storage-collection helpers** — created via a per-domain WebSocket collection command (`<domain>/create`, e.g. `input_boolean/create`, `counter/create`) with flat, structured fields: `input_boolean`, `input_number`, `input_select`, `input_text`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`, `zone`, `person`, `tag`. (`schedule` additionally offers an optional YAML mode.)
-- **Config-entry-flow helpers** — created through the generic config-entry flow (`config_entries/flow`, handler = the helper domain), often a multi-step flow that begins with a sub-type menu (see [Menu-Based Helpers](#menu-based-helpers)): `template`, `group`, `utility_meter`, `derivative`, `min_max`, `threshold`, `integration`, `statistics`, `trend`, `random`, `filter`, `tod`, `generic_thermostat`, `generic_hygrostat`, `switch_as_x`, `bayesian`, `mold_indicator`, `history_stats`.
+- **Storage-collection helpers** — created via a per-domain WebSocket collection command (`<domain>/create`, e.g. `input_boolean/create`, `counter/create`) with flat, structured fields: `input_boolean`, `input_number`, `input_select`, `input_text`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`, `zone`, `person`, `tag`. (All of these also accept YAML config except `tag`, which has none.)
+- **Config-flow helpers** — created through the generic config-entry flow (`config_entries/flow`, handler = the helper domain), often a multi-step flow that begins with a sub-type menu (see [Menu-Based Helpers](#menu-based-helpers)): `template`, `group`, `utility_meter`, `derivative`, `min_max`, `threshold`, `integration`, `statistics`, `trend`, `random`, `filter`, `tod`, `generic_thermostat`, `generic_hygrostat`, `switch_as_x`, `bayesian`, `mold_indicator`, `history_stats`.
 
 ## Menu-Based Helpers
 
@@ -38,6 +39,58 @@ Several helper integrations — most prominently **`template`**, **`group`**, an
 | `random` | `sensor`, `binary_sensor` |
 
 Advance the menu by submitting `{"next_step_id": "<sub-type>"}` to the first step; the resulting form's fields become available in the next step. The chosen sub-type is then written into the stored config entry as `template_type` / `group_type` etc. by the integration's validator — those are storage keys, not inputs the caller submits.
+
+## Reading the Examples in This File
+
+Each helper below shows the **flat field set its creation mechanism accepts** — the config-flow
+step fields, or the storage-collection `<domain>/create` fields. That is the one representation
+the UI form, a raw `config_entries/flow` call, and any programmatic helper API all consume;
+core reuses the same `CONF_*` constants for both paths, so the keys match.
+
+The older `sensor:` → `- platform: <helper>` YAML platform shape is **not** shown, because a
+helper created that way is not editable in the UI — its config lives in a file, not in a
+config entry — and applying a change needs a file edit plus a reload or a restart. To write
+one anyway (the user asked for YAML, or you need a YAML-only key), use the YAML root from the
+table below with managed YAML editing: see [yaml-only-integrations](yaml-only-integrations.md).
+
+**The post-edit action is per helper, not a blanket restart.** These ship a `<domain>.reload`
+that re-reads their YAML platform config: `min_max`, `filter`, `derivative`, `trend`,
+`statistics`, `bayesian`, `history_stats`, `generic_thermostat`, `group`, `template`. These
+have none, so a YAML change needs `homeassistant.restart` — confirm with the user first:
+`threshold`, `tod`, `integration`, `mold_indicator`, `random`, `switch_as_x`,
+`generic_hygrostat`, and `utility_meter` (whose services are `reset`/`calibrate` only).
+
+**`YAML-only:` lines are verified against core 2026.8.3.** Those keys exist on the YAML
+platform schema and have no config-flow field, so needing one is a reason to write YAML.
+A helper with no `YAML-only:` line has no such keys. Where the two shapes differ or the flow
+cannot express a case (`trend`, `tod`, `bayesian`, `filter`, `template`), both are shown.
+
+**`unique_id` is the one exception, and never a reason to choose YAML.** Most YAML platform
+schemas accept it; no flow does, because a flow-created helper gets one from its config entry.
+It is therefore omitted from the `YAML-only:` lines below. (`threshold` and `random` are the
+odd ones out — their YAML platforms accept *no* `unique_id`, so a YAML-defined entity there
+cannot be renamed or given an area from the UI.)
+
+**Two global conventions**, so they are not repeated per helper:
+- **Duration fields are mappings in flows** (`minutes: 5`), while the YAML platforms also
+  accept the `"00:05:00"` string. Exceptions are called out where they exist.
+- **The entity_id is derived from `name`** for both mechanisms, so a helper created as
+  "Average Temperature" becomes `sensor.average_temperature`. Renaming it later does not move
+  the entity_id.
+
+**Where a `YAML-only:` key sends you, the YAML root differs per helper** — it is not always
+`sensor:`:
+
+| Helper | YAML root |
+|---|---|
+| `min_max`, `statistics`, `derivative`, `integration`, `history_stats`, `filter`, `random`, `mold_indicator` | `sensor:` → `- platform: <helper>` |
+| `threshold`, `trend`, `tod`, `bayesian` | `binary_sensor:` → `- platform: <helper>` |
+| `generic_thermostat` | `climate:` → `- platform: generic_thermostat` |
+| `generic_hygrostat` | `humidifier:` → `- platform: generic_hygrostat` |
+| `utility_meter` | top-level `utility_meter:` → slug → fields (no `platform:`) |
+| `template` | top-level `template:` → `- sensor:` / `- binary_sensor:` / … |
+| `group` (old style) | top-level `group:` → slug → fields |
+| `switch_as_x` | none — config flow only |
 
 ---
 
@@ -61,18 +114,19 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - min_max helper
-sensor:
-  - platform: min_max
-    name: "Average Temperature"
-    type: mean
-    entity_ids:
-      - sensor.temp_bedroom
-      - sensor.temp_living
-      - sensor.temp_kitchen
+# RIGHT — min_max helper (config-flow fields)
+name: "Average Temperature"
+type: mean               # required
+entity_ids:
+  - sensor.temp_bedroom
+  - sensor.temp_living
+  - sensor.temp_kitchen
+round_digits: 2          # required in the flow, default 2
 ```
 
-**Available types:** `min`, `max`, `mean`, `median`, `last`, `sum`
+Note the key is `round_digits` here — `derivative` and `integration` spell the same idea `round`.
+
+**Available types:** `min`, `max`, `mean`, `median`, `last`, `range`, `sum`
 
 **Key behaviors:**
 - Ignores `unknown` states (except `sum` which goes to unknown)
@@ -101,23 +155,36 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Statistics helper
-sensor:
-  - platform: statistics
-    name: "Temperature Change (5 min)"
-    entity_id: sensor.temperature
-    state_characteristic: change
-    max_age:
-      minutes: 5
-    sampling_size: 50
+# RIGHT — statistics helper (config-flow submission, THREE steps — not one payload)
+# --- step 1 (user) ---
+name: "Temperature Change (5 min)"
+entity_id: sensor.temperature
+# --- step 2 (state_characteristic) ---
+state_characteristic: change   # options depend on sensor vs binary_sensor source
+# --- step 3 (options) ---
+sampling_size: 50
+max_age:                       # duration mapping
+  minutes: 5
+keep_last_sample: false
+percentile: 50                 # only used by the percentile characteristic
+precision: 2
 ```
 
-**Available characteristics:**
-- `mean`, `median`, `average_linear`, `average_step`, `average_timeless`
-- `standard_deviation`, `variance`
-- `change`, `change_second`, `change_sample`
-- `count`, `count_binary_on`, `count_binary_off`
-- `total`, `noisiness`
+
+**Available characteristics — numeric source** (27):
+`average_linear`, `average_step`, `average_timeless`, `change`, `change_sample`,
+`change_second`, `count`, `datetime_newest`, `datetime_oldest`, `datetime_value_max`,
+`datetime_value_min`, `distance_95_percent_of_values`, `distance_99_percent_of_values`,
+`distance_absolute`, `mean`, `mean_circular`, `median`, `noisiness`, `percentile`,
+`standard_deviation`, `sum`, `sum_differences`, `sum_differences_nonnegative`, `total`,
+`value_max`, `value_min`, `variance`
+
+**Binary-sensor source** (8): `average_step`, `average_timeless`, `count`, `count_on`,
+`count_off`, `datetime_newest`, `datetime_oldest`, `mean`
+
+The flow offers only the set valid for the chosen source, which is why
+`state_characteristic` is its own step. The binary values are `count_on` / `count_off` —
+`count_binary_on` / `count_binary_off` are the internal constant *names*, not accepted values.
 - `datetime_newest`, `datetime_oldest`, `datetime_value_max`, `datetime_value_min`
 - `value_max`, `value_min`, `quantiles`
 
@@ -150,25 +217,32 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Derivative helper
-sensor:
-  - platform: derivative
-    name: "Power Rate of Change"
-    source: sensor.power
-    unit_time: min
-    time_window:
-      minutes: 5
+# RIGHT — derivative helper (config-flow fields)
+name: "Power Rate of Change"
+source: sensor.power
+unit_time: h             # required in the flow, default h
+round: 2                 # required in the flow, default 2
+time_window:             # duration mapping, required in the flow
+  minutes: 5
+unit_prefix: k           # optional
+max_sub_interval:        # optional duration mapping
+  minutes: 1
 ```
 
 **Parameters:**
-- `unit_time`: s, min, h, d - determines output unit (e.g., W/min)
-- `time_window`: Smoothing window using Simple Moving Average
-- `round`: Decimal places for output
+- `unit_time`: `s`, `min`, `h`, `d` — determines output unit (e.g. W/min)
+- `time_window`: smoothing window using a Simple Moving Average
+- `round`: decimal places for output (the key is `round`, not `round_digits`)
+- `max_sub_interval`: forces a recalculation when the source stops updating
+
+**YAML-only:** `unit` — override the derived output unit outright. Reaching for it is a
+legitimate reason to write the YAML platform.
 
 **Key behaviors:**
 - Without `time_window`, calculates between consecutive updates only
 - Can show large negative spikes when source resets to 0 (total_increasing sensors)
-- Use `force_update` option if source updates infrequently
+- When the source updates infrequently, set `max_sub_interval` so the derivative decays to
+  zero instead of holding its last value
 
 **Common uses:**
 - Energy production rate (kW from kWh sensor)
@@ -192,19 +266,22 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Threshold helper
-binary_sensor:
-  - platform: threshold
-    name: "High Temperature"
-    entity_id: sensor.temperature
-    upper: 25
-    hysteresis: 1
+# RIGHT — threshold helper (config-flow fields)
+name: "High Temperature"
+entity_id: sensor.temperature
+upper: 25                # supply upper, lower, or both
+hysteresis: 1            # required in the flow, default 0
 ```
 
 **Parameters:**
-- `upper`: Threshold for "on" when value exceeds
-- `lower`: Threshold for "on" when value drops below
-- `hysteresis`: Buffer zone to prevent rapid toggling
+- `upper`: threshold for "on" when the value exceeds it
+- `lower`: threshold for "on" when the value drops below it
+- `hysteresis`: buffer zone to prevent rapid toggling
+- Supplying neither `upper` nor `lower` is rejected (`need_lower_upper`)
+
+**YAML-only:** `device_class`. Note the YAML platform accepts **no** `unique_id` here, so a
+YAML-defined threshold sensor cannot be renamed or assigned an area from the UI — a further
+reason to create it through the flow.
 
 **Hysteresis explained:**
 ```
@@ -236,22 +313,40 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Trend helper. NOTE: `sensors:` is a MAPPING keyed by a slug (not a list)
+# RIGHT — trend helper (config-flow submission, NOT configuration.yaml)
+# --- step 1 (user) ---
+name: "Temperature Rising"
+entity_id: sensor.temperature
+# --- step 2 (settings) ---
+attribute: null          # optional — track an attribute instead of the state
+invert: false            # true = detect a downward trend
+```
+
+**The tuning fields are not available at creation.** `sample_duration`, `min_gradient`,
+`max_samples`, and `min_samples` live in the **options** flow only — submitting them during
+creation fails with *extra keys not allowed*. Create the helper first, then reconfigure it to
+set them, or write the YAML platform (below), which takes all of them up front.
+
+**The two shapes differ here.** The YAML platform nests everything under a slug-keyed
+`sensors:` **mapping** (not a list), unlike most other `binary_sensor` platforms:
+
+```yaml
+# YAML platform shape — only when writing configuration.yaml
 binary_sensor:
   - platform: trend
     sensors:
       temp_rising:
         entity_id: sensor.temperature
-        sample_duration: 1800    # seconds of history to consider
-        min_gradient: 0.001      # units per SECOND to count as a trend
-        max_samples: 120        # cap on samples kept (independent of sample_duration)
-        invert: false            # true = detect a downward trend
+        sample_duration: 1800
+        min_gradient: 0.001
 ```
+
+**YAML-only:** `device_class`, `friendly_name`, plus the four tuning fields above.
 
 **Key behaviors:**
 - `min_gradient` is units **per second** (0.001 °/s ≈ 3.6 °/h).
+- `sample_duration` is a plain number of seconds in both shapes — not a duration mapping.
 - `invert: true` detects a *downward* trend.
-- `sensors:` is a slug-keyed mapping (not a list), unlike most other `binary_sensor` platforms.
 
 **Common uses:**
 - Temperature/pressure rising or falling
@@ -286,34 +381,35 @@ automation:
 
 **Use this:**
 ```yaml
-# RIGHT - Utility meter
-utility_meter:
-  daily_energy:
-    source: sensor.energy_consumption
-    cycle: daily
-  monthly_energy:
-    source: sensor.energy_consumption
-    cycle: monthly
+# RIGHT — utility_meter helper (config-flow fields)
+name: "Daily Energy"
+source: sensor.energy_consumption
+cycle: daily                  # required — the key is `cycle`, not `meter_type`
+offset: 0                     # required, default 0 — NUMBER OF DAYS (0-28) in the flow
+tariffs: []                   # required, default [] — e.g. ["peak", "offpeak"]
+net_consumption: false        # required, default false
+delta_values: false           # required, default false
+periodically_resetting: true  # required, default true
+always_available: false       # optional, default false
 ```
 
-**Cycle options:** `quarter-hourly`, `hourly`, `daily`, `weekly`, `monthly`, `bimonthly`, `quarterly`, `yearly`
+One meter per flow submission — the YAML shape's slug-keyed mapping creates several at once.
+
+**Cycle options:** `none`, `quarter-hourly`, `hourly`, `daily`, `weekly`, `monthly`, `bimonthly`, `quarterly`, `yearly`.
+`cycle` is required in the flow, so `none` is how you say "never resets" there; the YAML
+platform has no `none` — omit `cycle` instead.
 
 **Advanced features:**
-- **Tariffs:** Track peak/off-peak separately
-- **Offset:** Start cycle on specific day (e.g., billing date)
-- **Cron:** Custom reset schedules
-- **Delta:** For sensors that report delta values
+- **Tariffs:** Track peak/off-peak separately — creates a `select` entity to switch between them
+- **Offset:** Shift the cycle start (e.g. a billing date)
+- **Delta:** For sensors that report delta values rather than a running total
 
-```yaml
-# Utility meter with tariffs
-utility_meter:
-  daily_energy:
-    source: sensor.energy_consumption
-    cycle: daily
-    tariffs:
-      - peak
-      - offpeak
-```
+**YAML-only:** `cron` — custom reset schedules as a cron expression; the flow offers only
+the fixed `cycle` list. A non-standard billing period is the usual reason to
+write the YAML platform.
+
+**Value type differs:** the flow's `offset` is a **number of days** (0–28); the YAML
+platform's `offset` is a duration (`cv.time_period`).
 
 Then use automation to switch tariffs:
 ```yaml
@@ -342,14 +438,21 @@ automation:
 **Use for:** Statistics about how long/often an entity has been in a specific state.
 
 ```yaml
-sensor:
-  - platform: history_stats
-    name: "Lights on today"
-    entity_id: light.living_room
-    state: "on"
-    type: time
-    start: "{{ now().replace(hour=0, minute=0, second=0) }}"
-    end: "{{ now() }}"
+# history_stats helper (config-flow submission, THREE steps — not one payload)
+# --- step 1 (user) ---
+name: "Lights on today"
+entity_id: light.living_room
+type: time                    # time | ratio | count, default time
+# --- step 2 (state) ---
+state:                        # a LIST — several states can be counted together
+  - "on"
+# --- step 3 (options) ---
+start: "{{ today_at() }}"     # supply exactly two of start / end / duration
+end: "{{ now() }}"
+state_class: measurement
+additional_settings:          # collapsed section
+  min_state_duration:
+    minutes: 1
 ```
 
 **Types:**
@@ -357,12 +460,12 @@ sensor:
 - `ratio`: Percentage of time
 - `count`: Number of state changes to the monitored state
 
+
 **Key behaviors:**
 - Limited by recorder's `purge_keep_days`
 - Updates when source changes or once per minute
-- Creatable via the config-entry flow (multi-step: entity and type, then
-  tracked states, then the period — exactly two of `start`/`end`/`duration`);
-  YAML remains supported but is not required
+- `state` is a list in both shapes — several states can be counted together
+- `duration` is a duration mapping; `start` / `end` are templates
 
 **Common uses:**
 - How long lights were on today
@@ -376,20 +479,26 @@ sensor:
 **Use for:** Converting power (W) to energy (kWh), flow rate to volume, etc.
 
 ```yaml
-sensor:
-  - platform: integration
-    name: "Solar Energy"
-    source: sensor.solar_power
-    unit_prefix: k
-    unit_time: h
-    method: left
-    round: 2
+# integration (Riemann sum) helper (config-flow fields)
+name: "Solar Energy"
+source: sensor.solar_power
+method: left             # required, default trapezoidal
+unit_time: h             # required, default h
+unit_prefix: k           # optional
+round: 2                 # optional
+max_sub_interval:        # optional duration mapping
+  minutes: 1
 ```
 
 **Methods:**
 - `left`: Uses previous value for interval (recommended for sparse data)
 - `right`: Uses new value for interval
 - `trapezoidal`: Averages previous and new (can overestimate with gaps)
+
+**Do not set `unit`.** It was removed from this platform: `PLATFORM_SCHEMA` wraps
+`cv.removed("unit")`, which **raises** *"The 'unit' option has been removed"* and fails the
+config rather than ignoring the key. The unit is derived from the source plus
+`unit_prefix`/`unit_time`.
 
 **Key behaviors:**
 - For solar/sensors with gaps, use `left` method
@@ -404,6 +513,11 @@ sensor:
 
 ## State Storage
 
+These are **storage-collection helpers**: the fields below are the `<domain>/create` payload.
+The YAML shape nests the same fields under a slug you choose (`input_boolean:` → `guest_mode:`
+→ fields); through `<domain>/create` there is no slug — HA derives the entity_id from `name`.
+Renaming such a helper later does not move its entity_id, so pick the name deliberately.
+
 **Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, `input_select`, `input_text`, and `input_datetime` all accept an `initial` field. If `initial` is present in the config, HA forces that value on every restart instead of restoring the last saved state.
 - Omit `initial` to preserve state across restarts.
 - Use `initial` only when the helper must always start at a fixed value.
@@ -413,13 +527,10 @@ sensor:
 **Use for:** Toggle switches for modes, flags, and conditions.
 
 ```yaml
-input_boolean:
-  guest_mode:
-    name: "Guest Mode"
-    icon: mdi:account-group
-  vacation_mode:
-    name: "Vacation Mode"
-    icon: mdi:airplane
+# input_boolean — input_boolean/create fields
+name: "Guest Mode"       # required
+icon: mdi:account-group
+initial: false           # omit to restore the last state across restarts
 ```
 
 **Common uses:**
@@ -433,14 +544,13 @@ input_boolean:
 **Use for:** Storing numeric values that can be adjusted.
 
 ```yaml
-input_number:
-  target_temperature:
-    name: "Target Temperature"
-    min: 15
-    max: 30
-    step: 0.5
-    unit_of_measurement: "°C"
-    mode: slider
+# input_number — input_number/create fields
+name: "Target Temperature"   # required
+min: 15                      # required
+max: 30                      # required
+step: 0.5                    # default 1
+unit_of_measurement: "°C"
+mode: slider                 # slider (default) or box
 ```
 
 **Modes:** `slider`, `box`
@@ -456,15 +566,14 @@ input_number:
 **Use for:** Dropdown selection of predefined options.
 
 ```yaml
-input_select:
-  hvac_mode:
-    name: "HVAC Mode"
-    options:
-      - "auto"
-      - "cool"
-      - "heat"
-      - "off"
-    icon: mdi:thermostat
+# input_select — input_select/create fields
+name: "HVAC Mode"        # required
+options:                 # required, must be non-empty and unique
+  - "auto"
+  - "cool"
+  - "heat"
+  - "off"
+icon: mdi:thermostat
 ```
 
 **Common uses:**
@@ -478,12 +587,12 @@ input_select:
 **Use for:** Storing text strings.
 
 ```yaml
-input_text:
-  notification_message:
-    name: "Custom Notification"
-    min: 0
-    max: 255
-    mode: text
+# input_text — input_text/create fields
+name: "Custom Notification"   # required
+min: 0                        # default 0
+max: 255                      # default 100
+mode: text                    # text (default) or password
+pattern: null                 # optional regex the value must match
 ```
 
 **Modes:** `text`, `password`
@@ -498,15 +607,10 @@ input_text:
 **Use for:** Storing date and/or time values.
 
 ```yaml
-input_datetime:
-  morning_alarm:
-    name: "Morning Alarm"
-    has_time: true
-    has_date: false
-  next_vacation:
-    name: "Next Vacation"
-    has_date: true
-    has_time: false
+# input_datetime — input_datetime/create fields
+name: "Morning Alarm"    # required
+has_time: true           # at least one of has_date / has_time must be true
+has_date: false
 ```
 
 **Common uses:**
@@ -519,10 +623,9 @@ input_datetime:
 **Use for:** Triggering automations manually.
 
 ```yaml
-input_button:
-  doorbell:
-    name: "Doorbell"
-    icon: mdi:bell
+# input_button — input_button/create fields
+name: "Doorbell"         # required
+icon: mdi:bell
 ```
 
 **Common uses:**
@@ -556,15 +659,13 @@ automation:
 
 **Use this:**
 ```yaml
-# RIGHT - Counter helper
-counter:
-  coffee_count:
-    name: "Coffees Today"
-    initial: 0
-    step: 1
-    minimum: 0
-    maximum: 100
-    restore: true
+# RIGHT — counter helper (counter/create fields)
+name: "Coffees Today"    # required
+initial: 0               # default 0
+step: 1                  # default 1
+minimum: 0               # default null (no floor)
+maximum: 100             # default null (no ceiling)
+restore: true            # default true
 ```
 
 **Actions:** `counter.increment`, `counter.decrement`, `counter.reset`, `counter.set_value`
@@ -597,12 +698,10 @@ actions:
 
 **Use this for pausable/restartable timers:**
 ```yaml
-# RIGHT - Timer helper
-timer:
-  laundry:
-    name: "Laundry Timer"
-    duration: "01:00:00"
-    restore: true
+# RIGHT — timer helper (timer/create fields)
+name: "Laundry Timer"    # required
+duration: "01:00:00"     # default 0
+restore: true            # default false
 ```
 
 **Actions:** `timer.start`, `timer.pause`, `timer.cancel`, `timer.finish`, `timer.change`
@@ -633,16 +732,15 @@ timer:
 **Use for:** Weekly on/off schedules.
 
 ```yaml
-schedule:
-  work_hours:
-    name: "Work Hours"
-    monday:
-      - from: "09:00:00"
-        to: "17:00:00"
-    tuesday:
-      - from: "09:00:00"
-        to: "17:00:00"
-    # ... etc
+# schedule — schedule/create fields
+name: "Work Hours"       # required
+monday:
+  - from: "09:00:00"
+    to: "17:00:00"
+tuesday:
+  - from: "09:00:00"
+    to: "17:00:00"
+# each weekday key defaults to [] when omitted
 ```
 
 **Key behaviors:**
@@ -675,18 +773,30 @@ template:
 **Use for:** Binary sensor based on current time (sunrise/sunset or fixed times).
 
 ```yaml
-binary_sensor:
-  - platform: tod
-    name: "Morning"
-    after: "06:00"
-    before: "12:00"
+# tod helper (config-flow fields)
+name: "Morning"
+after_time: "06:00:00"    # required
+before_time: "12:00:00"   # required
+```
 
+**The two shapes use different key names — this trips up copy-paste.** The flow takes
+`after_time` / `before_time` and accepts **clock times only**. The YAML platform takes
+`after` / `before` and additionally accepts the sun events `sunrise` / `sunset` plus
+`after_offset` / `before_offset`:
+
+```yaml
+# YAML platform shape — required for sun-relative windows
+binary_sensor:
   - platform: tod
     name: "Night Time"
     after: sunset
     after_offset: "01:00:00"
     before: sunrise
 ```
+
+**YAML-only:** sun events as `after`/`before` values, `after_offset`, `before_offset`.
+A sun-relative window is a legitimate reason to write the YAML platform — or
+use a `sun` condition in the automation instead of a helper.
 
 **Common uses:**
 - Time-of-day modes (morning, afternoon, evening, night)
@@ -701,34 +811,43 @@ binary_sensor:
 
 **Use for:** Combining entities for collective state and control.
 
-```yaml
-group:
-  all_lights:
-    name: "All Lights"
-    entities:
-      - light.living_room
-      - light.bedroom
-      - light.kitchen
-    all: false  # ON if ANY member is on
+**Menu-based** — submit `{"next_step_id": "<sub-type>"}` first (sub-types: `binary_sensor`,
+`button`, `cover`, `event`, `fan`, `light`, `lock`, `media_player`, `notify`, `sensor`,
+`switch`, `valve`), then the fields for that sub-type. The stored config entry carries
+`group_type` as a storage key — not an input you submit.
 
-  security_sensors:
-    name: "Security Sensors"
-    entities:
-      - binary_sensor.front_door
-      - binary_sensor.back_door
-      - binary_sensor.window
-    all: true  # ON only if ALL members are on
+```yaml
+# group → light (config-flow fields, after next_step_id: light)
+name: "All Lights"       # required
+entities:                # required
+  - light.living_room
+  - light.bedroom
+  - light.kitchen
+hide_members: false      # required, default false
+all: false               # required, default false — ON if ANY member is on
 ```
 
-**Parameters:**
-- `all: false` (default): Group is ON if ANY member is ON (OR logic)
-- `all: true`: Group is ON only if ALL members are ON (AND logic)
+**Fields vary by sub-type — `all` is not universal.** Every sub-type takes `name`,
+`entities`, `hide_members`. Beyond that:
+
+| Sub-type | Additional fields |
+|---|---|
+| `binary_sensor`, `light`, `switch` | `all` (false = ON if any member is on; true = ON only if all are) |
+| `sensor` | `type` (required: `last`, `first_available`, `max`, `mean`, `median`, `min`, `product`, `range`, `stdev`, `sum`). `ignore_non_numeric` is **options-flow only** — not accepted at creation |
+| `button`, `cover`, `event`, `fan`, `lock`, `media_player`, `notify`, `valve` | none — `all` is **not** accepted |
+
+Sensor groups accept members from `sensor`, `number`, and `input_number`.
 
 **Key behaviors:**
 - Groups inherit the domain of their members
 - Light groups can be controlled as a single entity
 - Binary sensor groups useful for "any door open" logic
-- Created via the config-entry flow API, `group` is **menu-based**: submit `{"next_step_id": "<sub-type>"}` first (sub-types: `binary_sensor`, `button`, `cover`, `event`, `fan`, `light`, `lock`, `media_player`, `notify`, `sensor`, `switch`, `valve`), then provide `entities`. Sensor groups additionally require `type` (one of `last`, `first_available`, `max`, `mean`, `median`, `min`, `product`, `range`, `stdev`, `sum`). The stored config entry then carries `group_type` as a storage key.
+- `hide_members: true` hides the individual members from the UI, leaving only the group
+
+**Old-style YAML `group:` is a different thing** — a domain-agnostic mapping under a top-level
+`group:` key that predates the helper. It is still supported and takes only `name`, `entities`,
+`all`, and `icon`; it produces a `group.*` entity rather than a native entity of the members'
+domain. Prefer the helper.
 
 **Instead of:**
 ```yaml
@@ -755,30 +874,50 @@ template:
 
 **Use for:** Inferring an unmeasurable state (someone cooking, showering, room occupied) from several probabilistic signals — instead of hand-tuning a template with stacked `and`/`or`/threshold logic.
 
-**Use this:**
+**The one helper whose flow cannot be expressed as a flat field set.** Observations are added
+**one per flow round-trip** through an observation-type menu (`state`, `numeric_state`,
+`template`), so there is no single payload carrying an `observations` list. The YAML shape
+below is therefore the clearest spec of the configuration; build it in the flow one
+observation at a time.
+
 ```yaml
+# bayesian — YAML platform shape. NOTE THE SCALE: every probability here is 0..1.
+# The config flow wants the SAME numbers as PERCENTAGES (0.3 -> 30). Copying these
+# values into a flow is accepted and silently means 0.3%.
 binary_sensor:
   - platform: bayesian
     name: "Kitchen In Use"
-    prior: 0.3                  # baseline probability before any observation
-    probability_threshold: 0.5  # turns on when posterior probability exceeds this
+    prior: 0.3                  # flow: 30
+    probability_threshold: 0.5  # flow: 50
     observations:
       - entity_id: binary_sensor.kitchen_motion
         platform: state         # or numeric_state / template
         to_state: "on"
-        prob_given_true: 0.95
-        prob_given_false: 0.33
+        prob_given_true: 0.95   # flow: 95, and the flow also requires a `name` here
+        prob_given_false: 0.33  # flow: 33
       - entity_id: sensor.kitchen_power
         platform: numeric_state
         above: 50
-        prob_given_true: 0.8
-        prob_given_false: 0.05
+        prob_given_true: 0.8    # flow: 80
+        prob_given_false: 0.05  # flow: 5
 ```
+
+**Four differences between the shapes:**
+
+| | YAML platform | Config flow |
+|---|---|---|
+| Probability scale | `0..1` (`prior: 0.3`) | percentages `0..100` (`prior: 30`), and exactly 0 or 100 is rejected |
+| Observations | one `observations:` list | one submission per observation, via a type menu |
+| Per-observation `name` | not accepted | **required** on every observation |
+| `prob_given_false` | optional | required |
 
 **Key behaviors:**
 - Each observation contributes `prob_given_true` / `prob_given_false`; the sensor turns on when the combined posterior probability exceeds `probability_threshold`.
 - Observation `platform` is `state`, `numeric_state` (uses `above`/`below`), or `template` (uses `value_template`).
-- **YAML uses probabilities `0..1`; the UI config flow uses percentages `0..100`** — a common mismatch.
+- Two `numeric_state` observations on the **same entity** may not have overlapping
+  `above`/`below` ranges — the YAML platform rejects the config with `overlapping_ranges`.
+- The observation schemas are closed: an unexpected key fails validation rather than being ignored.
+
 
 **Common uses:**
 - "Someone is cooking" / "shower running" from motion + power + humidity
@@ -805,7 +944,24 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Filter helper (UI creates one filter per entry; YAML supports chains)
+# RIGHT — filter helper (config-flow submission, TWO steps), one filter per entry
+# --- step 1 (user) ---
+name: "Filtered Temperature"
+entity_id: sensor.outdoor_temp
+filter: outlier          # picks which fields step 2 offers — see the table below
+# --- step 2 (the chosen filter's step) ---
+window_size: 4
+radius: 2.0
+precision: 2             # available on every filter type
+```
+
+**Two things are YAML-only here.** The flow creates exactly one filter per config entry, so
+**chains** need YAML. The flow's source picker also accepts `sensor` entities only, while the
+YAML platform accepts `sensor`, `binary_sensor`, **and** `input_number` — so filtering a
+binary sensor or an input_number needs YAML too. For a chain, write the `filters:` list:
+
+```yaml
+# YAML platform shape — required for chains
 sensor:
   - platform: filter
     name: "Filtered Temperature"
@@ -821,7 +977,7 @@ sensor:
         precision: 2
 ```
 
-**The UI config flow creates one filter per entry.** For chained pipelines (multiple filters applied in sequence), use YAML as above.
+(You can also chain by pointing one filter helper's `entity_id` at another's output entity.)
 
 **Filter types** (one per UI entry, or multiple in a YAML list):
 
@@ -855,13 +1011,11 @@ template:
 
 **Use this:**
 ```yaml
-# RIGHT - Random helper (proper entity with state class, history, etc.)
-sensor:
-  - platform: random
-    name: "Random Percentage"
-    minimum: 0
-    maximum: 100
-    unit_of_measurement: "%"
+# RIGHT — random → sensor (config-flow fields, after next_step_id: sensor)
+name: "Random Percentage"
+minimum: 0               # default 0
+maximum: 100             # default 20
+unit_of_measurement: "%"
 ```
 
 Menu-based — pick `sensor` (numeric) or `binary_sensor` (boolean).
@@ -876,10 +1030,12 @@ Menu-based — pick `sensor` (numeric) or `binary_sensor` (boolean).
 
 Binary-sensor variant (boolean coin-flip — no min/max needed):
 ```yaml
-binary_sensor:
-  - platform: random
-    name: "Random Boolean"
+# random → binary_sensor (after next_step_id: binary_sensor)
+name: "Random Boolean"
 ```
+
+The YAML platform accepts no `unique_id` for either sub-type, so a YAML-defined random sensor
+is not UI-editable. There is no reason to prefer YAML for this helper.
 
 ---
 
@@ -890,27 +1046,40 @@ binary_sensor:
 **Use for:** Turning a switch (or fan) into a thermostat that follows a temperature sensor.
 
 ```yaml
-climate:
-  - platform: generic_thermostat
-    name: "Bedroom"
-    heater: switch.bedroom_heater
-    target_sensor: sensor.bedroom_temperature
-    ac_mode: false
-    cold_tolerance: 0.3
-    hot_tolerance: 0.3
-    min_temp: 15
-    max_temp: 25
-    min_cycle_duration: "00:05:00"
+# generic_thermostat helper (config-flow submission, TWO steps)
+# --- step 1 (user) ---
+name: "Bedroom"                # required
+heater: switch.bedroom_heater  # required — a switch or fan entity
+target_sensor: sensor.bedroom_temperature   # required — a temperature sensor
+ac_mode: false                 # required — true inverts for cooling
+cold_tolerance: 0.3            # required, default 0.3
+hot_tolerance: 0.3             # required, default 0.3
+min_cycle_duration:            # optional duration mapping
+  minutes: 5
+max_cycle_duration: null       # optional duration mapping
+cycle_cooldown: null           # optional duration mapping
+keep_alive: null               # optional duration mapping
+min_temp: 15                   # optional
+max_temp: 25                   # optional
+# --- step 2 (presets) — all optional ---
+away_temp: 16
+comfort_temp: 21
+eco_temp: 18
+home_temp: 20
+sleep_temp: 17
+activity_temp: 20
 ```
 
-**Parameters (config flow):**
-- Required: `name`, `heater` (switch or fan entity), `target_sensor` (temperature sensor), `ac_mode` (bool — set `true` to invert for cooling).
-- Optional: `cold_tolerance` (default `0.3`), `hot_tolerance` (default `0.3`), `min_cycle_duration`, `max_cycle_duration`, `cycle_cooldown`, `keep_alive`, `min_temp`, `max_temp`, plus a presets step (`away_temp`, `comfort_temp`, `eco_temp`, `home_temp`, `sleep_temp`, `activity_temp`).
+**YAML-only:** `initial_hvac_mode`, `precision`, `target_temp_step`, `target_temp`.
+Needing a fixed startup mode or a custom temperature step is a legitimate
+reason to write the YAML platform.
+
+**Value type differs:** the duration fields are mappings (`minutes: 5`) in the flow; the
+YAML platform also accepts the `"00:05:00"` string form.
 
 **Key behaviors:**
 - `ac_mode: true` inverts logic (heater output activates for cooling)
 - Tolerances prevent rapid cycling near the target
-- YAML platform supports `initial_hvac_mode`, `precision`, `target_temp_step` — not exposed by the UI flow
 
 ---
 
@@ -919,20 +1088,21 @@ climate:
 **Use for:** Turning a switch (or fan) into a humidifier/dehumidifier controller that follows a humidity sensor.
 
 ```yaml
-humidifier:
-  - platform: generic_hygrostat
-    name: "Bathroom Dehumidifier"
-    device_class: dehumidifier
-    humidifier: switch.bathroom_fan
-    target_sensor: sensor.bathroom_humidity
-    dry_tolerance: 3
-    wet_tolerance: 3
-    min_cycle_duration: "00:05:00"
+# generic_hygrostat helper (config-flow fields)
+name: "Bathroom Dehumidifier"   # required
+device_class: dehumidifier      # required — humidifier or dehumidifier
+humidifier: switch.bathroom_fan # required — a switch or fan entity
+target_sensor: sensor.bathroom_humidity   # required — a humidity sensor
+dry_tolerance: 3                # required, default 3
+wet_tolerance: 3                # required, default 3
+min_cycle_duration:             # optional duration mapping
+  minutes: 5
 ```
 
-**Parameters (config flow):**
-- Required: `name`, `device_class` (`humidifier` or `dehumidifier`), `humidifier` (switch or fan entity), `target_sensor` (humidity sensor).
-- Optional: `dry_tolerance` (default `3`), `wet_tolerance` (default `3`), `min_cycle_duration`.
+**YAML-only, and there are many:** `min_humidity`, `max_humidity`, `target_humidity`,
+`keep_alive`, `initial_state`, `away_humidity`, `away_fixed`, `sensor_stale_duration`.
+This helper's flow is markedly thinner than its YAML platform — an away preset
+or a stale-sensor timeout requires YAML.
 
 ---
 
@@ -941,13 +1111,14 @@ humidifier:
 **Use for:** Estimating mold/condensation risk from indoor temperature + humidity vs. a cold-surface (outdoor) temperature — instead of hand-rolling a dew-point template.
 
 ```yaml
-sensor:
-  - platform: mold_indicator
-    indoor_temp_sensor: sensor.indoor_temp
-    indoor_humidity_sensor: sensor.indoor_humidity
-    outdoor_temp_sensor: sensor.outdoor_temp
-    calibration_factor: 2.0
+# mold_indicator helper (config-flow fields)
+name: "Mold Indicator"                        # required, default "Mold Indicator"
+indoor_temp_sensor: sensor.indoor_temp        # required
+indoor_humidity_sensor: sensor.indoor_humidity # required
+outdoor_temp_sensor: sensor.outdoor_temp      # required
+calibration_factor: 2.0                       # required in the flow, optional in YAML
 ```
+
 
 Outputs an estimated humidity-at-cold-surface percentage; mold risk rises above ~70%. **`calibration_factor` must be physically calibrated** to a known condensation point — it is not a value to guess.
 
@@ -976,9 +1147,13 @@ template:
         state: "{{ is_state('switch.lamp_plug', 'on') }}"
 ```
 
-**Use this** (UI / config flow — no YAML equivalent):
-- `entity_id: switch.lamp_plug`
-- `target_domain: light`
+**Use this** (config-flow fields — no YAML equivalent at all):
+```yaml
+# switch_as_x helper (config-flow fields)
+entity_id: switch.lamp_plug   # required — must be a switch.* entity
+target_domain: light          # required
+invert: false                 # default false
+```
 
 `switch_as_x` hides the original switch and registers a proper `light.*` entity that voice assistants and dashboards treat correctly.
 
@@ -992,7 +1167,7 @@ UI-only — no YAML equivalent. The original switch entity is hidden once conver
 
 ## Template Helpers
 
-When no dedicated helper covers your need, use the **Template Helper** — created via the config-entry flow / UI, **not** YAML `template:` platform sensors. Template helpers are first-class HA helpers: UI-editable, reloadable without restarting, and visible in the helper registry.
+When no dedicated helper covers your need, use the **Template Helper** — created through the config flow, **not** YAML `template:` platform sensors, except for the cases in the YAML-only table below. Template helpers are first-class HA helpers: UI-editable, reloadable without restarting, and visible in the helper registry.
 
 ### template
 
@@ -1000,39 +1175,78 @@ When no dedicated helper covers your need, use the **Template Helper** — creat
 
 Menu-based — pick a sub-type first (see [Menu-Based Helpers](#menu-based-helpers) for the full sub-type list), then configure fields.
 
+**`availability` is nested, not flat.** Every sub-type puts `availability` (and
+`location_accuracy`) inside a collapsed **`additional_options`** section. A flat
+`availability:` at the top of the payload fails validation. HA flattens the section when it
+sets the entry up, which is why the YAML platform shape shows the key at the top level.
+
 **template → sensor**
 - Required: `name`, `state` (Jinja template returning the sensor value)
-- Optional: `unit_of_measurement`, `device_class`, `state_class`, `device_id`, `availability` (template)
+- Optional: `unit_of_measurement`, `device_class`, `state_class`, `device_id`; `availability` inside `additional_options`
 
 **template → binary_sensor**
 - Required: `name`, `state` (Jinja template returning truthy/falsy)
-- Optional: `device_class`, `device_id`, `availability` (template)
+- Optional: `device_class`, `device_id`; `availability` inside `additional_options`
 
 **template → device_tracker** (the native replacement for the legacy `device_tracker.see` action)
-- Required: **either** `in_zones` (a list of zone entity_ids the device is considered in) **or** both `latitude` and `longitude` (templates)
-- Optional: `location_accuracy`, plus the common `name`/`unique_id`/`icon`/`picture`/`availability`/`attributes`
-- Not valid here: `location_name`, `battery_level`, `source_type`, `host_name`, `mac_address`, `gps_accuracy`
+- Required: `name`, and **either** `in_zones` (a list of zone entity_ids the device is considered in) **or** both `latitude` and `longitude` (templates)
+- Optional: `device_id`; `availability` and `location_accuracy` inside `additional_options`
+- **YAML-only:** `icon`, `picture` (and `unique_id`, as everywhere)
+- Not valid here in **either** shape: `attributes`. Nor: `location_name`, `battery_level`, `source_type`, `host_name`, `mac_address`, `gps_accuracy`
 
 Other sub-types follow the same shape — a `state` template plus domain-appropriate metadata.
+
+```yaml
+# template → sensor (config-flow fields, after next_step_id: sensor)
+name: "Solar Net"        # required
+state: "{{ states('sensor.solar_production') | float(0) - states('sensor.house_consumption') | float(0) }}"
+unit_of_measurement: "W"
+device_class: power
+state_class: measurement
+device_id: null          # optional — attach the entity to an existing device
+additional_options:      # collapsed section — availability lives HERE, not at top level
+  availability: "{{ has_value('sensor.solar_production') and has_value('sensor.house_consumption') }}"
+```
+
+**Do not submit `unique_id`** — the flow assigns one from the config entry. It is a
+YAML-platform field only.
 
 **State restoration (2026.8+):** `fan`, `cover`, and `device_tracker` template entities
 restore their previous state after a restart, so they resume where they left off instead
 of coming back blank.
 
-**Equivalent YAML platform** (for reference; prefer the helper):
+**The YAML platform shape** — needed for the cases the flow cannot express (below), and for
+defining several entities at once:
 ```yaml
 template:
   - sensor:
       - name: "Solar Net"
-        state: "{{ states('sensor.solar_production') | float - states('sensor.house_consumption') | float }}"
+        unique_id: solar_net
+        state: "{{ states('sensor.solar_production') | float(0) - states('sensor.house_consumption') | float(0) }}"
         unit_of_measurement: "W"
         device_class: power
         state_class: measurement
   - binary_sensor:
       - name: "Someone Home"
+        unique_id: someone_home
         state: "{{ is_state('person.alice','home') or is_state('person.bob','home') }}"
         device_class: presence
 ```
+
+**YAML-only for template entities** (verified against the Template Helper flow at 2026.8.3):
+
+| YAML-only | Why the flow cannot do it |
+|---|---|
+| **Trigger-based templates** (`triggers:` / `action:` / `variables:` on the block) | The flow has no trigger step. Its per-sub-type action fields (`press`, `turn_on`, `set_value`, …) are entity *commands*, not a trigger block's `actions:` |
+| `attributes:` (extra state attributes) | No field in the flow |
+| Several entities in one block | One entity per config entry |
+
+(`unique_id` is not in this table: the flow assigns one. See the note at the top of this file.)
+
+Needing a trigger, `attributes:`, or several entities in one block is a legitimate reason to
+write `template:` YAML — see
+[template-guidelines](template-guidelines.md), which covers when templates are the right tool
+at all.
 
 See the [Decision Matrix](#decision-matrix) for when the Template Helper is the right choice vs. a dedicated helper — every pattern that has a dedicated helper (averaging, rate of change, thresholds, time-of-day, scheduling, any-on/all-on) should go through that helper first.
 
@@ -1068,4 +1282,5 @@ See the [Decision Matrix](#decision-matrix) for when the Template Helper is the 
 | Infer an unmeasurable state from several signals | `bayesian` | Template with stacked and/or logic |
 | Switch presented as light/cover/lock | `switch_as_x` | Template light/cover/lock |
 | Random sensor value | `random` | Template with `range()` |
-| Custom logic no other helper covers | `template` helper (via UI flow) | YAML `template:` platform sensor |
+| Custom logic no other helper covers | `template` helper (via config flow) | YAML `template:` platform sensor |
+| Template entity that must update on a trigger, or carry `attributes:` | YAML `template:` block — the flow has no equivalent | Forcing it into the flow |

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -170,7 +170,6 @@ percentile: 50                 # only used by the percentile characteristic
 precision: 2
 ```
 
-
 **Available characteristics — numeric source** (27):
 `average_linear`, `average_step`, `average_timeless`, `change`, `change_sample`,
 `change_second`, `count`, `datetime_newest`, `datetime_oldest`, `datetime_value_max`,
@@ -185,8 +184,6 @@ precision: 2
 The flow offers only the set valid for the chosen source, which is why
 `state_characteristic` is its own step. The binary values are `count_on` / `count_off` —
 `count_binary_on` / `count_binary_off` are the internal constant *names*, not accepted values.
-- `datetime_newest`, `datetime_oldest`, `datetime_value_max`, `datetime_value_min`
-- `value_max`, `value_min`, `quantiles`
 
 **Key behaviors:**
 - Time-based (`max_age`) vs count-based (`sampling_size`) buffering

--- a/skills/home-assistant-best-practices/references/scenes.md
+++ b/skills/home-assistant-best-practices/references/scenes.md
@@ -1,5 +1,7 @@
 # Scenes
 
+> **The YAML below shows config shape, not a file to hand-edit.** Create and update these through the HA config API, which validates the config and needs no restart. Scenes have a config API like automations and scripts; editing `scenes.yaml` is the fallback, not the default.
+
 A scene is a **saved snapshot of target entity states, applied atomically** — not a sequential script. Activating it pushes every listed entity toward its stored state at once (optionally with a transition). Use a scene to *restore a set of states*; use a script's `sequence` when you need ordered, conditional, or timed steps.
 
 ## Table of Contents
@@ -14,18 +16,18 @@ A scene is a **saved snapshot of target entity states, applied atomically** — 
 ## Scene Config Shape
 
 ```yaml
-scene:
-  - name: Romantic            # required; `id:` optional but recommended (stable unique id)
-    icon: "mdi:flower-tulip"  # optional
-    entities:
-      light.tv_back_light: "on"          # simple form: entity_id → state string
-      light.ceiling:                      # object form: state + attributes
-        state: "on"
-        brightness: 200                   # 0–255
-        color_temp_kelvin: 2700           # Kelvin — NOT color_temp/mireds (removed 2026.3)
-      climate.living_room:
-        state: "heat"
-        temperature: 21
+# One scene object, as submitted to the config API (no `scene:` file wrapper)
+name: Romantic            # required; `id:` optional but recommended (stable unique id)
+icon: "mdi:flower-tulip"  # optional
+entities:
+  light.tv_back_light: "on"          # simple form: entity_id → state string
+  light.ceiling:                     # object form: state + attributes
+    state: "on"
+    brightness: 200                  # 0–255
+    color_temp_kelvin: 2700          # Kelvin — NOT color_temp/mireds (removed 2026.3)
+  climate.living_room:
+    state: "heat"
+    temperature: 21
 ```
 
 - `entities` is a dict mapping `entity_id` → a state string, or an object with `state` plus the entity's attributes.

--- a/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -1,7 +1,16 @@
 > **Prefer a Template Helper over YAML.**
-> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or via the UI:
-> Settings → Devices & Services → Helpers → Create Helper → Template.
-> Use `template:` YAML only when explicitly requested or when neither programmatic nor UI access is available.
+> Before writing any `template:` block, create a Template Helper through the HA config flow
+> (programmatically, or in the UI: Settings → Devices & Services → Helpers → Create Helper →
+> Template). It is UI-editable; a `template:` YAML entry needs a `template.reload` and is not.
+>
+> **Write `template:` YAML when** the user asks for it, when neither path is available, or when
+> the entity needs something the flow has no field for — **trigger-based templates**,
+> **`attributes:`**, or several entities in one block. Those cases are real and are marked
+> *YAML-only* throughout this file; see
+> [helper-selection #template-helpers](helper-selection.md#template-helpers) for the full list.
+> The YAML blocks below show **config shape**. Where one is the thing to write, use managed
+> YAML editing ([yaml-only-integrations](yaml-only-integrations.md)) — never an unchecked
+> hand-edit.
 
 # Template Guidelines
 
@@ -180,7 +189,11 @@ See [automation-patterns](automation-patterns.md) and [helper-selection](helper-
 
 ## Template Sensor Best Practices
 
-### Always Include unique_id
+### Always Include unique_id — in YAML blocks only
+
+A `unique_id` is what gives the entity a registry entry, so the UI can rename it, assign it
+to an area, and customize it — and so a later rename sticks instead of being regenerated from
+`name` on the next reload. **Every `template:` YAML entity needs one.**
 
 ```yaml
 template:
@@ -189,6 +202,10 @@ template:
         unique_id: my_custom_sensor  # Enables UI customization
         state: "{{ states('sensor.source') }}"
 ```
+
+**Do not submit `unique_id` to the Template Helper flow** — it is not a field there; the
+config entry supplies one. This is the single most common key to wrongly carry over when
+converting a YAML block into a helper.
 
 ### Always Define Availability
 
@@ -245,33 +262,42 @@ template:
         state: "{{ states('sensor.amps') | float * 230 }}"
 ```
 
-### Use Trigger-Based for Efficiency
+### Use Trigger-Based to Capture Trigger Context
 
-Trigger-based templates only update when sources change:
+Trigger-based templates re-evaluate only when their trigger fires, and are the **only**
+template form with access to the `trigger` variable. That second property is the real reason
+to reach for them: a state-based template is recomputed from current states and therefore
+cannot know *which* entity changed, or what the previous value was.
 
 ```yaml
+# Trigger-based: records WHICH sensor fired — impossible in a state-based template
 template:
   - triggers:                    # Recommended plural form (HA 2024.10+)
       - trigger: state
         entity_id:
-          - sensor.temp_bedroom
-          - sensor.temp_living
+          - binary_sensor.motion_hall
+          - binary_sensor.motion_kitchen
+        to: "on"
     sensor:
-      - name: "Average Temperature"
-        state: >
-          {% set temps = [
-            states('sensor.temp_bedroom') | float(0),
-            states('sensor.temp_living') | float(0)
-          ] %}
-          {{ (temps | sum / temps | count) | round(1) }}
-        unit_of_measurement: "°C"
-        state_class: measurement
+      - name: "Last Motion"
+        unique_id: last_motion
+        state: "{{ trigger.to_state.name }}"
+        attributes:
+          entity_id: "{{ trigger.entity_id }}"
+          at: "{{ now().isoformat() }}"
 ```
 
-**Benefits of trigger-based:**
-- Only evaluates when trigger fires (not on every state change)
-- Access to `trigger` variable
-- More efficient for complex templates
+**Trigger-based blocks are YAML-only** — the Template Helper flow has no trigger step, and
+no `attributes:` field. This example uses both.
+
+**Use trigger-based when you need:**
+- The `trigger` variable — which entity fired, `from_state` / `to_state`, event data
+- A value captured at an instant rather than recomputed (timestamps, "last X")
+- A deliberately throttled update (a `time_pattern` trigger over an expensive template)
+
+**Do not** reach for it to average or sum entities — that is a `min_max` helper, not a
+template, whether or not a trigger is involved. See
+[helper-selection #numeric-aggregation](helper-selection.md#numeric-aggregation).
 
 ### YAML Block Structure Conventions (HA 2024.10+)
 
@@ -567,22 +593,26 @@ template:
 
 > The legacy per-domain template-sensor form (`sensor:` → `- platform:` → `sensors:` → `value_template:`, i.e. a `template` platform nested under a domain key) was **removed in HA 2026.6** and no longer loads. Use the top-level `template:` integration key with `state:`, as above.
 
-### Use Trigger-Based Templates for Complex Logic
+### Throttle an Expensive Template With a Time Trigger
+
+A `time_pattern` trigger caps how often an expensive template runs, regardless of how often
+its sources change. Use it for genuinely expensive work — not for aggregation, which is a
+[`min_max`](helper-selection.md#numeric-aggregation) helper.
 
 ```yaml
-# EFFICIENT - Only runs when specified triggers fire
+# Runs every 5 minutes instead of on every source change
 template:
   - triggers:
       - trigger: time_pattern
-        minutes: "/5"  # Every 5 minutes
+        minutes: "/5"
     sensor:
-      - name: "Complex Calculation"
+      - name: "Grid Import Cost Today"
+        unique_id: grid_import_cost_today
         state: >
-          {% set total = 0 %}
-          {% for sensor in states.sensor | selectattr('attributes.device_class', 'eq', 'energy') %}
-            {% set total = total + states(sensor.entity_id) | float(0) %}
-          {% endfor %}
-          {{ total }}
+          {{ (states('sensor.grid_import_today') | float(0)
+              * states('input_number.tariff_rate') | float(0)) | round(2) }}
+        unit_of_measurement: "EUR"
+        device_class: monetary
 ```
 
 ### Cache Complex Calculations

--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -6,7 +6,7 @@ This does NOT apply to:
 
 - Automations/scripts/scenes (use config APIs)
 - `.storage/` files (use REST/WebSocket APIs)
-- UI-configured integrations and helpers (config flow): `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations
+- UI-configured integrations and helpers (config flow): `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations — **unless the helper's flow has no field for the config you need**, which is a real and common case: see the `YAML-only:` lines in [helper-selection](helper-selection.md)
 
 Old-style YAML `group:` blocks are still YAML-only and appear in the table below — only the UI Group Helper is excluded.
 
@@ -16,14 +16,15 @@ For sending notifications, prefer config-flow notify integrations (Mobile App, T
 
 | Integration type | Post-edit action | Notes |
 |---|---|---|
-| `template` | `template.reload` | Simple template entities: prefer the UI Template Helper. Trigger-based templates and multi-entity blocks (shared triggers/variables) still require YAML. |
+| `template` | `template.reload` | Simple template entities: prefer the Template Helper. Trigger-based templates, `attributes:`, and multi-entity blocks (shared triggers/variables) still require YAML. |
 | `command_line` | `command_line.reload` | Sensors, switches, binary sensors via shell commands |
 | `rest` | `rest.reload` | REST sensors, binary sensors |
 | `shell_command` | `shell_command.reload` | Named shell command definitions |
 | `mqtt` (platform-based) | `mqtt.reload` | Platform-style `mqtt:` sensors/switches. MQTT Discovery and MQTT device config entries are non-YAML alternatives for auto-published devices |
+| `utility_meter` | `homeassistant.restart` | Top-level `utility_meter:` → slug → fields (no `platform:`). Needed for `cron` reset schedules, which the config flow cannot express |
 | `group` (YAML-defined) | `group.reload` | Old-style YAML groups. Prefer the UI Group Helper (Settings → Devices & Services → Helpers → Group) for new groups |
 | `sensor` / `binary_sensor` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `sensor:` (or `binary_sensor:`) key with a block sequence of `- platform: <name>` entries — for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
-| `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `switch:` / `light:` / etc. key with a block sequence of `- platform: <name>` entries — only for platforms that have no config flow. Check the integration's docs before assuming YAML is required |
+| `switch` / `light` / `fan` / `cover` / `climate` / `humidifier` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `switch:` / `light:` / etc. key with a block sequence of `- platform: <name>` entries — only for platforms that have no config flow. Check the integration's docs before assuming YAML is required |
 
 ## Post-Edit Actions
 


### PR DESCRIPTION
## What does this PR do?

Resolves the skill's oldest coherence problem: it told agents to create helpers through the
config flow, then showed every helper as a `sensor: - platform: <helper>` YAML block — the
file-edit path it forbids. Agents pattern-match on examples far more strongly than on prose
directives, so the examples were winning.

**Each helper now shows the flat field set its creation mechanism accepts** — the config-flow
step fields, or the storage-collection `<domain>/create` fields. Core reuses the same `CONF_*`
constants for both schemas, so this is the one representation the UI form, a raw
`config_entries/flow` call, and any programmatic helper API all consume. It is *more*
transport-agnostic than the platform blocks it replaces, and it names no tool.

### The doctrine gains its missing exception

YAML was permitted only when the user asks or no other path is available. The common real case
is a third one: **the config needs a key the flow has no field for.** Those are now marked per
helper with the correct YAML root (`climate:`, `humidifier:`, top-level `utility_meter:` — it
is not always `sensor:`) and the correct post-edit action.

### Divergences the sweep found

All 15 flow helpers and 9 storage-collection helpers were verified against core `2026.8.3`.
These silently break a config copied from one shape into the other:

| Helper | Divergence |
|---|---|
| `trend` | The four tuning fields are **options-flow only** — submitting them at creation fails with *extra keys not allowed* |
| `tod` | Flow takes `after_time`/`before_time`, clock times only; YAML takes `after`/`before` plus sun events and offsets |
| `bayesian` | Flow uses percentages `0..100` where YAML uses `0..1`; adds one observation per round-trip; requires a per-observation `name` that YAML rejects |
| `utility_meter` | Flow `offset` is a number of days; YAML's is a duration. `cron` is YAML-only |
| `filter` | Chains are YAML-only, and the flow accepts only `sensor` sources while the platform also takes `binary_sensor` and `input_number` |
| `group` | `all` is accepted only by `binary_sensor`/`light`/`switch`; `sensor` takes `type`, and `ignore_non_numeric` is options-flow only |
| `template` | `availability` nests inside an `additional_options` section; trigger-based blocks and `attributes:` have no flow field |
| `integration` | `unit` is **rejected** by `cv.removed()`, not ignored |
| `threshold`, `random` | YAML platforms accept **no** `unique_id`, so a YAML-defined entity there is not UI-editable |

### Defects removed

- **`derivative`'s `force_update`** was fabricated — zero occurrences in `derivative/sensor.py`.
  Replaced with `max_sub_interval`, the real mechanism.
- **"Platform-style YAML has no reload action"** was wrong for the majority: ten of these
  helpers ship a `reload` service. Replaced with the actual per-helper split.
- **`min_max`** was missing the `range` type; **`statistics`** listed `count_binary_on` /
  `count_binary_off` (constant *names*; the values are `count_on` / `count_off`), a `quantiles`
  characteristic that does not exist, and omitted eight real ones; **`utility_meter`** omitted
  the `none` cycle.
- **Blueprints** are authored by `blueprint/save` over WebSocket (validated, no hand-edit),
  not only by writing the file.

### examples.yaml

Drops the `automation:` / `script:` file wrappers so each example is the object submitted to
the config API; parses as a 7-document stream. Example 7 (MQTT) stays file shape and says so
inline. Example 4 replaces `.replace('_window','')` entity-id string surgery with
`area_id: "{{ area_id(trigger.entity_id) }}"`, which follows the area registry and is visible
to the consumer search `safe-refactoring.md` mandates.

### Review

Four independent reviewers with non-overlapping mandates (source fact-check, adversarial
fabrication-hunting, internal consistency, and consumer simulation) audited the change. They
found nine defects in the new text — all corrected here, each re-verified against core before
editing. Notably, the fact-checker *confirmed* several claims that the adversarial pass then
disproved: every error was a plausible over-generalization, which a confirm-oriented check
does not catch.

### Also in this PR

`CLAUDE.md` gains the two merge gates it was missing (`agnix`, `lychee` — previously only
`skills-ref` was documented, so the others had to be reverse-engineered from workflow YAML),
plus the helper verification recipe this change was built on: claims need both
`config_flow.py` and the platform `PLATFORM_SCHEMA`, and the three traps in reading them that
each produced a defect here.

## Checklist

- [x] Tested with real scenarios (if changing skill content)
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)

**On testing:** every claim is verified against `home-assistant/core` at tag `2026.8.3`, twice
and independently — the second pass diffed `PLATFORM_SCHEMA` against `config_flow.py`
programmatically and caught two wrong `unique_id` claims from the first. Scenario coverage is
a reviewer simulating seven real helper-creation tasks against the text. Local gates pass:
`skills-ref validate`, `agnix` (0 errors), `lychee --offline --include-fragments` (216/0),
`examples.yaml` parses, description 978/1024, `metadata.version` untouched.
**Not done:** the `evals/` cases still have never been executed — there is no workspace to run
them in. Two new evals are added here for the exception path but are unrun, like the other 13.

**No reference files were added or removed**, so the README table needed no change; its rows
still describe every file accurately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Home Assistant guidance to prioritize config-flow and API-based setup over direct YAML editing.
  * Clarified when YAML remains necessary, including trigger-based templates, unsupported fields, and YAML-only integrations.
  * Improved helper-selection, template, dashboard, scene, blueprint, device-control, and AppDaemon guidance.
  * Updated examples to distinguish API object format from file-based YAML and added safer configuration practices.
* **Tests**
  * Added evaluations covering trigger-based templates and threshold helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
