### PR TITLE
docs(readme): correct installer requirements and resync Skill Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ This repository provides an Agent Skill for Home Assistant, following the open [
 
 ## Included Skill
 
-**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, button and remote patterns, device control best practices, YAML-only integration management, dashboard configuration, and safe refactoring.
+**[home-assistant-best-practices](skills/home-assistant-best-practices/):** Native HA constructs over templates, helper selection, automation modes, button and remote patterns, device control, scenes, blueprints, YAML-only integration management, dashboard configuration, AppDaemon apps, backups and recovery, and safe refactoring.
 
 ## Installation
 
 ### Agent Skills installer
 
-Requires [Node.js 18+](https://nodejs.org/).
+Requires [Node.js 22.20+](https://nodejs.org/).
 
 ```bash
 npx skills add homeassistant-ai/skills
 ```
 
-Works with AI coding agents that support the [Agent Skills standard](https://agentskills.io): Claude Code, Cursor, Copilot, VS Code, Gemini CLI, and others. To update: `npx skills update`
+Works with AI coding agents that support the [Agent Skills standard](https://agentskills.io): Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI, and 70+ others. To update: `npx skills update`
 
 ### Claude Code plugin
 
@@ -42,9 +42,9 @@ Both apps share the same Customize UI, reached via the left sidebar (Claude Desk
 
 1. Enable code execution: Settings → Capabilities → turn on **Cloud code execution and file creation** (required for skills)
 2. Customize → Plugins → Add → Add marketplace → Add from a repository
-3. Enter `homeassistant-ai/skills` (or the full URL, `https://github.com/homeassistant-ai/skills`) → Sync
+3. Select or enter `homeassistant-ai/skills` (or the full URL, `https://github.com/homeassistant-ai/skills`) → Sync
 
-This installs the skill as a plugin synced from this repo — no download or zip needed. To update later, go to Plugins, click the `skills` marketplace tag, open its `⋯` menu, and choose **Check for updates** (or toggle **Sync automatically**).
+This installs the skill as a plugin synced from this repo — no download or zip needed. To update later, go to Plugins → **Browse** → **Personal**, open the `⋯` menu on the `skills` marketplace tag, and choose **Check for updates** (or toggle **Sync automatically**).
 
 <details>
 <summary>Alternative: upload the skill manually as a zip</summary>
@@ -63,18 +63,18 @@ The `home-assistant-best-practices` skill includes:
 | File | Purpose |
 |------|---------|
 | [`SKILL.md`](skills/home-assistant-best-practices/SKILL.md) | Decision workflow and quick-reference routing |
-| [`references/safe-refactoring.md`](skills/home-assistant-best-practices/references/safe-refactoring.md) | Safe workflow for renaming entities, replacing helpers, restructuring automations |
-| [`references/automation-patterns.md`](skills/home-assistant-best-practices/references/automation-patterns.md) | Native conditions, triggers, waits, automation modes |
+| [`references/safe-refactoring.md`](skills/home-assistant-best-practices/references/safe-refactoring.md) | Safe workflow for renaming entities, replacing helpers, restructuring automations; config-entry and storage-dashboard blind spots |
+| [`references/automation-patterns.md`](skills/home-assistant-best-practices/references/automation-patterns.md) | Purpose-specific and native triggers/conditions, waits, variables, automation modes, control flow (choose, repeat, parallel), disabling automations |
 | [`references/helper-selection.md`](skills/home-assistant-best-practices/references/helper-selection.md) | Built-in helpers vs template sensors (with decision matrix) |
 | [`references/template-guidelines.md`](skills/home-assistant-best-practices/references/template-guidelines.md) | When to use templates, when to avoid them, sensor best practices, reusable `custom_templates` macros |
 | [`references/yaml-only-integrations.md`](skills/home-assistant-best-practices/references/yaml-only-integrations.md) | YAML-only integration types, post-edit actions (reload vs restart) |
-| [`references/device-control.md`](skills/home-assistant-best-practices/references/device-control.md) | Service calls, entity_id vs device_id, buttons and remotes |
+| [`references/device-control.md`](skills/home-assistant-best-practices/references/device-control.md) | Actions and targeting, entity_id vs device_id, buttons and remotes, domain-specific patterns |
 | [`references/scenes.md`](skills/home-assistant-best-practices/references/scenes.md) | Scene authoring: config shape, snapshot/restore, snapshot-vs-script distinction |
-| [`references/dashboard-guide.md`](skills/home-assistant-best-practices/references/dashboard-guide.md) | Dashboard layout, view types, sections, custom cards, CSS styling |
+| [`references/dashboard-guide.md`](skills/home-assistant-best-practices/references/dashboard-guide.md) | Dashboard layout, view types, strategies, sections, cards, badges, custom cards, CSS styling, HACS |
 | [`references/dashboard-cards.md`](skills/home-assistant-best-practices/references/dashboard-cards.md) | Card type lookup and card-specific documentation |
-| [`references/domain-docs.md`](skills/home-assistant-best-practices/references/domain-docs.md) | Integration and domain documentation for service calls, entity attributes |
+| [`references/domain-docs.md`](skills/home-assistant-best-practices/references/domain-docs.md) | Integration and domain documentation (actions, entity attributes); doc pages for specific triggers, conditions, and actions |
 | [`references/examples.yaml`](skills/home-assistant-best-practices/references/examples.yaml) | Compound examples combining multiple best practices |
-| [`references/appdaemon.md`](skills/home-assistant-best-practices/references/appdaemon.md) | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact |
+| [`references/appdaemon.md`](skills/home-assistant-best-practices/references/appdaemon.md) | AppDaemon apps: when to use vs. native HA, app structure, actions, scheduling, error handling, safe refactoring impact |
 | [`references/blueprint-guide.md`](skills/home-assistant-best-practices/references/blueprint-guide.md) | Blueprint authoring: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, `!input` templating, versioning |
 | [`references/backups.md`](skills/home-assistant-best-practices/references/backups.md) | Full instance backups vs rolling one object back, when an operation needs a backup first, what an archive contains, encryption keys, restore verification, backup deletion |
 


### PR DESCRIPTION
## What does this PR do?

Corrects README claims that no longer match the tooling or the skill.

**Agent Skills installer**
- Node requirement was 18+; the `skills` package declares `engines: >=22.20.0`, so Node 18 or 20 fails at install.
- VS Code was listed as a supported agent — it is not one of the installer's 71 targets. Copilot is listed upstream as GitHub Copilot.

**Claude Desktop / claude.ai**
- The update path said to click the `skills` marketplace tag on the Plugins list. That tag is under Plugins → Browse → Personal; a reader following the old wording clicks the plugin instead, whose `⋯` menu offers only **Remove**.
- The Add-marketplace URL field is a repository picker, so "select or enter".

The rest of that section (the **Cloud code execution and file creation** toggle, the Add → Add marketplace → Add from a repository path, Skills → Add → Upload a skill) was checked against the live UI and is accurate as written.

**Skill Contents**
- Three rows said "service calls" — renamed to actions in 2024.8, and `CONTRIBUTING.md` requires one term per concept.
- `automation-patterns` omitted purpose-specific triggers/conditions, the default building block since 2026.7 and step 1 of SKILL.md's workflow.
- `safe-refactoring` omitted the config-entry and storage-dashboard blind spots the reference exists for.
- `dashboard-guide` omitted strategies, badges, and HACS.
- The skill summary omitted scenes, blueprints, AppDaemon, and backups, all of which the table below it already listed.

Rows now match SKILL.md's own reference table.

## Checklist

- [ ] Tested with real scenarios (if changing skill content)
- [x] `README.md` Skill Contents table updated (if reference files were added or removed)
