### PR TITLE
chore: resync skill descriptions, action placeholder, update path, and drift checklist

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "homeassistant-mcp@qc-h.net"
   },
   "metadata": {
-    "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, device control, and dashboards",
+    "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, scenes, blueprints, device control, dashboards, AppDaemon, and backups",
     "version": "0.24.0"
   },
   "plugins": [
     {
       "name": "home-assistant-skills",
-      "description": "Best practices for Home Assistant automations, helpers, scripts, device controls, and dashboards",
+      "description": "Best practices for Home Assistant automations, helpers, scripts, scenes, blueprints, device control, dashboards, AppDaemon apps, and backups",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "home-assistant-skills",
-  "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, device control, and dashboards.",
+  "description": "Agent skills for Home Assistant: best practices for automations, helpers, templates, scenes, blueprints, device control, dashboards, AppDaemon, and backups.",
   "version": "0.24.0",
   "repository": "https://github.com/homeassistant-ai/skills",
   "license": "MIT"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,4 @@
 
 - [ ] Tested with real scenarios (if changing skill content)
 - [ ] `README.md` Skill Contents table updated (if reference files were added or removed)
+- [ ] Row descriptions and the **Included Skill** summary still match what the files cover (if a reference file's scope changed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,13 @@ graders are compiled with `node`, not Python `re`: the two disagree (`re` reject
 `(?<name>x)` and accepts Python-only `(?P<name>x)`), and without `node` that check is skipped
 with a warning rather than failed.
 
-Three things nothing checks, so all three stay review items: that every reference file is
-still routed from SKILL.md, that `references/examples.yaml` still parses, and that an eval
-grader still means what it was written to mean.
+Four things nothing checks, so all four stay review items: that every reference file is
+still routed from SKILL.md, that `references/examples.yaml` still parses, that an eval
+grader still means what it was written to mean, and that the descriptions in SKILL.md's
+reference table and README's **Skill Contents** table still match what the files cover.
+The last one drifts silently — link checking keeps the *file list* honest while the prose
+beside it goes stale, so a row can point at the right file and still describe an older
+version of it.
 
 ## Reviewing Skill PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,4 +59,5 @@ The template covers five sections: context, timeline, root cause, impact, and en
 3. Write a `SKILL.md` following the format above.
 4. Test your skill with real scenarios.
 5. If you added or removed reference files, link them from `SKILL.md`'s reference table and update the **Skill Contents** table in `README.md`. CI checks that links resolve, but nothing detects a reference file that nothing links to.
-6. Submit a pull request describing what your skill teaches and what problems it solves.
+6. If you materially changed what a reference file *covers* — a new section, a scope the old description no longer implies — update its row in both `SKILL.md`'s reference table and `README.md`'s **Skill Contents** table, and the one-line skill summary under **Included Skill**. The file list staying correct is not the same as the descriptions staying correct: nothing checks the descriptions, and they are what routes a reader to the right file.
+7. Submit a pull request describing what your skill teaches and what problems it solves.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Both apps share the same Customize UI, reached via the left sidebar (Claude Desk
 2. Customize → Plugins → Add → Add marketplace → Add from a repository
 3. Select or enter `homeassistant-ai/skills` (or the full URL, `https://github.com/homeassistant-ai/skills`) → Sync
 
-This installs the skill as a plugin synced from this repo — no download or zip needed. To update later, go to Plugins → **Browse** → **Personal**, open the `⋯` menu on the `skills` marketplace tag, and choose **Check for updates** (or toggle **Sync automatically**).
+This installs the skill as a plugin synced from this repo — no download or zip needed. **Sync automatically** is on by default, so later updates arrive on their own.
 
 <details>
 <summary>Alternative: upload the skill manually as a zip</summary>

--- a/skills/home-assistant-best-practices/references/device-control.md
+++ b/skills/home-assistant-best-practices/references/device-control.md
@@ -473,7 +473,7 @@ actions:
 
 ```yaml
 actions:
-  - action: domain.service_name   # Required
+  - action: <domain>.<name>       # Required
     target:                       # Optional but recommended
       entity_id: entity.id        # Single or list
       area_id: area_name          # Single or list


### PR DESCRIPTION
## What does this PR do?

**Plugin descriptions were describing an older, smaller skill.**

All three description fields — `plugin.json` `.description`, `marketplace.json` `.metadata.description`, and `.plugins[0].description` — listed automations, helpers, templates, device control, and dashboards. The skill has since gained `scenes.md`, `blueprint-guide.md`, `appdaemon.md`, and `backups.md`, none of which were mentioned.

`.plugins[0].description` is the text rendered on the plugin's page in the Claude Desktop / claude.ai Customize UI, so this is user-facing, not just manifest hygiene.

Version fields are untouched — those are managed by `auto-bump-version.yml`.

**`device-control.md` quick reference used pre-2024.8 terminology, in a form that fails late.**

The Action Structure block's placeholder was `action: domain.service_name`, in a file whose own headings read "Action Best Practices" and "Quick Reference: Action Structure". HA renamed services to actions in 2024.8, and `CONTRIBUTING.md` requires one term per concept.

Replaced with `<domain>.<name>` rather than `domain.action_name`. HA validates an action name with `service()` in `homeassistant/helpers/config_validation.py`, which requires `valid_entity_id` — so `domain.action_name` **passes** validation as a well-formed slug pair. A literal copy would save cleanly and only fail when the action is called. `<domain>.<name>` fails validation immediately, matches the wording of HA's own error message, and is the placeholder form already used in `SKILL.md`, `domain-docs.md`, `automation-patterns.md`, `blueprint-guide.md`, and `helper-selection.md`. Comment alignment preserved; the block still parses as YAML.

Two other `service` occurrences in the skill were checked and deliberately left: `dashboard-guide.md:314` cites `call-service` as the old name of `perform-action`, which is the documented way to handle a rename; `appdaemon.md:171` describes AppDaemon's literal `domain/service_name` Python API, not HA terminology.

**The claude.ai update instructions documented the rare case as the normal one.**

Follow-up to #84, which rewrote that sentence into a five-step path through Plugins → Browse → Personal to reach **Check for updates**, with **Sync automatically** as a parenthetical.

That toggle is on by default when a marketplace is added, so almost nobody needs the path. Observed alongside: a marketplace pinned at commit `502296b` advanced to the repo tip `4c3361a` with no manual check run. The sentence now states that updates arrive on their own, and the manual path is dropped.

**The contributor checklist only asked about added and removed files.**

`CONTRIBUTING.md` step 5 and the PR template both asked for a Skill Contents update when reference files were *added or removed*. Nothing asked for one when a file's **scope** changed — which is why the file list stayed correct through every PR in this repo's history while three row descriptions and the Included Skill summary went stale. Link checking keeps a row pointing at the right file; it says nothing about whether the prose beside it still describes that file.

Both now also cover scope changes, and `CLAUDE.md`'s "three things nothing checks" list becomes four, naming description drift alongside the existing review items.

This is the weakest of the fixes — the add/remove rule already existed and still didn't prevent the drift, which is the argument for checking these mechanically instead. Filed as a starting point, not a solution.

## Checklist

- [ ] Tested with real scenarios (if changing skill content) — not run: the skill-content
      change is a placeholder in a quick-reference block, with no behavioural surface to
      exercise against an instance. Verified against HA core source at tag 2026.8.3 instead.
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed)
- [ ] Row descriptions and the **Included Skill** summary still match what the files cover
      (if a reference file's scope changed) — n/a: no reference file changed scope here;
      the rows were resynced in #84
