### PR TITLE
docs: check for a native dashboard-screenshot capability before browser automation

### DIFF
--- a/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -576,9 +576,14 @@ Custom cards predating sections views (early 2024) that haven't updated since ar
 
 ## Visual Iteration Workflow
 
-Where browser automation is available, render the dashboard and look at it rather than
-reasoning about the JSON: write the config through the HA API, open
-`{base_url}/lovelace/{url_path}`, screenshot, adjust, repeat.
+Render the dashboard and look at it rather than reasoning about the JSON. Check the
+connected MCP server's tool list for a native dashboard-screenshot capability first —
+some servers ship one (sometimes as an opt-in/beta feature the user must enable), and it
+renders a view directly with no browser stack. Prefer the screenshot-only call for
+re-checks when you already hold the config; a combined config+screenshot call earns its
+payload only when you need both. Otherwise, where browser automation is available: write
+the config through the HA API, open `{base_url}/lovelace/{url_path}`, screenshot, adjust,
+repeat.
 
 **Read `{base_url}` from the instance; never assume `:8123`.** Since 2026.8 a new Home
 Assistant OS install serves on a plain web address with no port suffix, and the port is


### PR DESCRIPTION
## What does this PR do?

Reworks the opening of dashboard-guide.md's Visual Iteration Workflow so agents check the connected MCP server's tool list for a native dashboard-screenshot capability (often opt-in/beta) before adding a browser-automation MCP server, and prefer the screenshot-only call over a combined config+screenshot round trip when they already hold the config.

Motivated by homeassistant-ai/ha-mcp#2293: an agent following this section stood up nothing and fell back to re-fetching the full dashboard config alongside every render. Wording stays generic — no MCP tool names, per the authoring principles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the dashboard visual iteration guidance to recommend checking for native screenshot capabilities before using browser automation.
  * Clarified when to use screenshot-only versus combined configuration-and-screenshot workflows.
  * Retained browser-based validation as a fallback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->