### PR TITLE
doc(helpers): add multi-port solar micro-inverter aggregation pattern for Energy Dashboard

### DIFF
--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -138,6 +138,29 @@ Note the key is `round_digits` here — `derivative` and `integration` spell the
 - Maximum power consumption across circuits
 - Sum of all solar panel production sensors
 
+#### Multi-Port Solar Micro-Inverter Aggregation (Energy Dashboard)
+
+For multi-port solar micro-inverters (e.g. Hoymiles dual-port HMS-1000W-2T with individual DC Port 1 & 2 sensors, Enphase, APSystems), the Home Assistant Energy Dashboard requires a single cumulative energy entity. `min_max` with `type: sum` does not pass through `state_class: total_increasing` or `device_class: energy`, so use a **Template Helper**:
+
+```yaml
+# WRONG — adding raw instantaneous power (W) or a template sensor without cumulative energy attributes to the Energy Dashboard
+template:
+  - sensor:
+      - name: "Solar Power Sum"
+        state: "{{ states('sensor.port_1_power') | float + states('sensor.port_2_power') | float }}"
+
+# RIGHT — Template helper aggregating multi-port cumulative energy with mandatory Energy Dashboard metadata
+name: "Total Solar Energy"
+state: "{{ (states('sensor.inverter_dc_port_1_energy') | float(0)) + (states('sensor.inverter_dc_port_2_energy') | float(0)) }}"
+unit_of_measurement: "Wh"     # or "kWh" matching input sensors
+device_class: energy          # required by Energy Dashboard
+state_class: total_increasing # required for cumulative meter tracking
+additional_options:
+  availability: "{{ has_value('sensor.inverter_dc_port_1_energy') and has_value('sensor.inverter_dc_port_2_energy') }}"
+```
+
+Also ensure grid tariff index sensors (e.g. Peak / Off-peak) carry distinct friendly names to prevent ambiguous duplicate headers in Energy Dashboard summary tables.
+
 ---
 
 ### statistics

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -140,7 +140,7 @@ Note the key is `round_digits` here — `derivative` and `integration` spell the
 
 #### Multi-Port Solar Micro-Inverter Aggregation (Energy Dashboard)
 
-For multi-port solar micro-inverters (e.g. Hoymiles dual-port HMS-1000W-2T with individual DC Port 1 & 2 sensors, Enphase, APSystems), the Home Assistant Energy Dashboard requires a single cumulative energy entity. `min_max` with `type: sum` does not pass through `state_class: total_increasing` or `device_class: energy`, so use a **Template Helper**:
+For multi-port solar micro-inverters (e.g. Hoymiles dual-port HMS-1000W-2T with individual DC Port 1 & 2 sensors, Enphase, APSystems), the Home Assistant Energy Dashboard requires a single cumulative energy entity. While `min_max` with `type: sum` inherits `device_class: energy` when all source entities share it, it sets `state_class: measurement` rather than preserving `state_class: total_increasing`. For cumulative solar energy tracking in the Energy Dashboard, use a **Template Helper**:
 
 ```yaml
 # WRONG — adding raw instantaneous power (W) or a template sensor without cumulative energy attributes to the Energy Dashboard
@@ -156,7 +156,7 @@ unit_of_measurement: "Wh"     # or "kWh" matching input sensors
 device_class: energy          # required by Energy Dashboard
 state_class: total_increasing # required for cumulative meter tracking
 additional_options:
-  availability: "{{ has_value('sensor.inverter_dc_port_1_energy') and has_value('sensor.inverter_dc_port_2_energy') }}"
+  availability: "{{ is_number(states('sensor.inverter_dc_port_1_energy')) and is_number(states('sensor.inverter_dc_port_2_energy')) }}"
 ```
 
 Also ensure grid tariff index sensors (e.g. Peak / Off-peak) carry distinct friendly names to prevent ambiguous duplicate headers in Energy Dashboard summary tables.


### PR DESCRIPTION
Resolves #89

### Summary of Changes

- Added explicit guidance in `references/helper-selection.md` under Numeric Aggregation for multi-port solar micro-inverters (Hoymiles, Enphase, APSystems) configured for the Home Assistant Energy Dashboard.
- Provided standard `# WRONG` vs `# RIGHT` patterns detailing mandatory metadata attributes:
  - `device_class: energy`
  - `state_class: total_increasing`
  - `unit_of_measurement: Wh` (or `kWh`)
  - `availability` filter in `additional_options`
- Added note regarding distinct naming for grid tariff index sensors (e.g., Peak / Off-peak) to avoid duplicate headers in Energy Dashboard tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for aggregating multi-port solar micro-inverter energy in the Home Assistant Energy Dashboard.
  * Clarified that `min_max` sum helpers may inherit energy device classification but use measurement state classification, making a Template Helper necessary for cumulative energy tracking.
  * Updated recommended and incorrect template examples, including improved availability checks and required energy metadata.
  * Recommended distinct names for grid tariff index sensors to avoid ambiguous Energy Dashboard labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->