### PR TITLE
docs(helpers): correct min_max guidance for Energy Dashboard sources

### DIFF
--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -132,11 +132,14 @@ Note the key is `round_digits` here — `derivative` and `integration` spell the
 - Ignores `unknown` states (except `sum` which goes to unknown)
 - Returns error if unit of measurement differs between sensors
 - For spiky values, filter with statistics sensor first
+- Always `state_class: measurement`, so the recorder compiles `mean`/`min`/`max` and never `sum` (`DEFAULT_STATISTICS` in `sensor/recorder.py`)
+- Energy Dashboard consequence: a `sum` of energy (kWh) sensors plots nothing and is flagged `entity_state_class_measurement_no_last_reset`. Adding `last_reset` silences that issue but still plots nothing; energy sources need `total` or `total_increasing`. Add each energy sensor as its own dashboard source instead, which the dashboard sums for display. The grid, gas and water power slots (`stat_rate`) are the opposite case: they require `measurement`, which a `sum` of power sensors satisfies
+- Since 2026.3, `device_class` is inherited only when every entity in `entity_ids` carries the same one, evaluated once at setup
 
 **Common uses:**
 - Average house temperature from multiple room sensors
 - Maximum power consumption across circuits
-- Sum of all solar panel production sensors
+- Sum of solar power (W) across arrays; for kWh use [integration](#integration-riemann-sum)
 
 ---
 
@@ -1255,6 +1258,7 @@ See the [Decision Matrix](#decision-matrix) for when the Template Helper is the 
 |------|--------|-----|
 | Average of multiple sensors | `min_max` (type: mean) | Template with math |
 | Sum of multiple sensors | `min_max` (type: sum) | Template with math |
+| Sum of energy (kWh) sensors for the Energy Dashboard | Add each sensor as its own dashboard source | `min_max` (type: sum): `measurement` never compiles `sum` statistics |
 | Average over time | `statistics` | Template tracking history |
 | Rate of change | `derivative` | Template calculating delta |
 | On/off at threshold | `threshold` | Template binary sensor |

--- a/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/skills/home-assistant-best-practices/references/helper-selection.md
@@ -133,7 +133,7 @@ Note the key is `round_digits` here — `derivative` and `integration` spell the
 - Returns error if unit of measurement differs between sensors
 - For spiky values, filter with statistics sensor first
 - Always `state_class: measurement`, so the recorder compiles `mean`/`min`/`max` and never `sum` (`DEFAULT_STATISTICS` in `sensor/recorder.py`)
-- Energy Dashboard consequence: a `sum` of energy (kWh) sensors plots nothing and is flagged `entity_state_class_measurement_no_last_reset`. Adding `last_reset` silences that issue but still plots nothing; energy sources need `total` or `total_increasing`. Add each energy sensor as its own dashboard source instead, which the dashboard sums for display. The grid, gas and water power slots (`stat_rate`) are the opposite case: they require `measurement`, which a `sum` of power sensors satisfies
+- Energy Dashboard consequence: a `sum` of energy (kWh) sensors plots nothing and is flagged `entity_state_class_measurement_no_last_reset`. Adding `last_reset` silences that issue but still plots nothing; energy sources need `total` or `total_increasing`. Add each energy sensor as its own dashboard source instead, which the dashboard sums for display. The grid `stat_rate` slot is the opposite case: it requires `measurement` with `device_class: power`, which a `sum` of power sensors satisfies (gas and water `stat_rate` take `volume_flow_rate` instead)
 - Since 2026.3, `device_class` is inherited only when every entity in `entity_ids` carries the same one, evaluated once at setup
 
 **Common uses:**


### PR DESCRIPTION
## What does this PR do?

Corrects `min_max` guidance in `references/helper-selection.md`, which pointed readers at a helper that cannot serve as an Energy Dashboard source.

`min_max` sets `_attr_state_class = SensorStateClass.MEASUREMENT` as a class attribute, so every type carries it, and it never sets `last_reset`. The recorder compiles `mean`/`min`/`max` for `measurement` sensors and never `sum` (`DEFAULT_STATISTICS` in `sensor/recorder.py`). The Energy Dashboard reads `sum`, so a `min_max` sum of energy sensors plots nothing and validation flags `entity_state_class_measurement_no_last_reset`. Adding `last_reset` clears that warning without changing what the recorder compiles, so the warning is a symptom rather than the cause.

Two places sent readers there. **Common uses** listed "Sum of all solar panel production sensors", and the **Decision Matrix** routes "Sum of multiple sensors" to `min_max` (type: sum), which is the row a reader with an aggregation question actually reaches.

Changes:

- Key behaviors gain the recorder behaviour, its Energy Dashboard consequence, and the remedy: add each energy sensor to the dashboard as its own source.
- The grid, gas and water `stat_rate` slots are named as the opposite case. `_async_validate_power_stat` requires `measurement` and never checks `last_reset`, so a `sum` of power sensors is valid there. It runs for those three only.
- `device_class` inheritance is pinned to 2026.3. It is absent at 2026.2.0 and present at 2026.3.0, and it is evaluated once at setup rather than on later source changes.
- The solar line now covers power (W) and points at the `integration` helper for kWh.
- A Decision Matrix row covers the energy case.

Reported in #94, which carried the `state_class` observation. That PR proposed a combined template sensor instead; the Energy Dashboard takes several sources per category, and summing `total_increasing` meters trips the reset detection in `_detect_statistic_reset` when one meter resets, so the fix is on this line rather than a new pattern. Closes #89.

Verified against `home-assistant/core` at 2026.9.0.

## Checklist

- [ ] Tested with real scenarios (if changing skill content). Verified against `home-assistant/core` at 2026.9.0 by reading source, not on a live instance.
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed). Not applicable, no reference files added or removed.
- [x] Row descriptions and the **Included Skill** summary still match what the files cover (if a reference file's scope changed). A caveat inside an existing section is not a scope change; both rows still describe the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for `min_max` helpers, including measurement state classification and device class inheritance.
  * Clarified Energy Dashboard behavior for energy sensors, including supported state classes and individual dashboard source configuration.
  * Added guidance for grid, gas, and water rate sensors.
  * Refined recommendations for summing solar power and energy sensors, including using integration for kWh calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->