### PR TITLE
docs(yaml-only): note that http is no longer YAML-configured

### DIFF
--- a/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -6,6 +6,7 @@ This does NOT apply to:
 
 - Automations/scripts/scenes (use config APIs)
 - `.storage/` files (use REST/WebSocket APIs)
+- `http` (2026.8+): moved to a storage-backed store with a WebSocket API (`http/config/configure`), managed from Settings → System → Network. A `configuration.yaml` `http:` block is imported once and then ignored, and HA raises a repair issue asking the user to remove it
 - UI-configured integrations and helpers (config flow): `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations — **unless the helper's flow has no field for the config you need**, which is a real and common case: see the `YAML-only:` lines in [helper-selection](helper-selection.md)
 
 Old-style YAML `group:` blocks are still YAML-only and appear in the table below — only the UI Group Helper is excluded.


### PR DESCRIPTION
## What does this PR do?

Adds `http` to the exclusion list in `references/yaml-only-integrations.md`, so an agent configuring a reverse proxy does not reach for `configuration.yaml`.

HA 2026.8 moved HTTP configuration into a storage-backed store with a WebSocket API (`http/config`, `http/config/configure`, `http/config/promote`), managed from Settings > System > Network. An `http:` block in `configuration.yaml` is imported once and then ignored, and HA raises a repair issue asking for its removal: `deprecated_yaml` says "The `http` integration is now configured from the UI ... Please remove the `http:` block", and `yaml_still_present_after_migration` covers the case where it is left behind.

Scoped deliberately to one line in the exclusion list. This skill covers automations, helpers, scripts, and dashboards, not network administration, so the `configure` and `promote` sequence and its auto-revert behaviour are out of scope here. The file's exclusion list exists to answer "is this YAML-only?", and for `http` the answer is now no.

Reported in #91. That report's own steps were writing an `http:` block to `configuration.yaml` and then editing `.storage/http` by hand, both of which the skill description already lists as symptoms ("User told to edit configuration.yaml for UI integrations", "Direct .storage edits"). The only fact the skill was missing is the one this line adds. Closes #91.

Verified against `home-assistant/core` at 2026.9.0: `homeassistant/components/http/config.py` returns 404 at tag `2026.7.0` and exists at `2026.8.0`.

## Checklist

- [ ] Tested with real scenarios (if changing skill content). Verified against `home-assistant/core` at 2026.9.0 by reading source, not on a live instance.
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed). Not applicable, no reference files added or removed.
- [x] Row descriptions and the **Included Skill** summary still match what the files cover (if a reference file's scope changed). An exclusion-list entry does not change the file's scope; the row still reads "Creating or editing YAML-only integrations that have no config flow".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that, starting with version 2026.8, the `http` integration is managed through Settings → System → Network and its WebSocket API.
  - Documented that existing `configuration.yaml` `http:` settings are imported once and then ignored.
  - Noted that Home Assistant creates a repair issue prompting users to remove the obsolete configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->