### PR TITLE
docs(rca-template): add guards for the failure modes in the last batch

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-rca.md
+++ b/.github/ISSUE_TEMPLATE/skill-rca.md
@@ -29,9 +29,15 @@ INSTRUCTIONS FOR THE AGENT
 A skill in this repository misled you, and your user saw the result.
 
 BEFORE FILING:
-- Search existing issues for the same skill and failure. If a matching
-  issue exists, react with thumbs-up or comment with additional context.
-  Open a new issue only when the failure is unreported.
+- Do not re-run any step that changed the user's config. Decide from
+  evidence you already have whether the failure is HA's or your tool's:
+  compare the bytes your tool sent with what HA stored, read HA's own log
+  line, check the state the entity actually holds. Corrupted text is
+  usually the tool. A stale cache or an unapplied write can be either; the
+  core file or docs page that produces the behaviour decides. If the
+  evidence points at the tool, there is no skill gap: do not file. If you
+  cannot tell, say so in 3b and file only if the skill's guidance would
+  still have changed what you did.
 - Did the skill actually load? If it never triggered, this is a triggering
   failure, not a content failure: write "Skill did not trigger" in 3a, keep
   the user's request verbatim apart from redactions (it is the prompt that
@@ -39,6 +45,17 @@ BEFORE FILING:
 - Did you follow the skill's guidance? If you skipped guidance that would
   have prevented the failure, that is not a skill bug. Report only what the
   skill got wrong or left out.
+- Did your fix break a rule? A step you marked Success that does something
+  the Critical Anti-Patterns table in the skill's SKILL.md forbids is a
+  second failure, not a fix. The test is the path, not the tool: anything
+  you wrote under .storage/, or any configuration.yaml edit for a
+  UI-configured integration, counts. Mark that row Failure, and in 3c give
+  the supported path or say you did not find one.
+- One failure per report. If your timeline has two unrelated [GAP] rows,
+  file two reports.
+- Search existing issues for the same skill and failure. If a matching
+  issue exists, react with thumbs-up or comment with additional context.
+  Open a new issue only when the failure is unreported.
 - Redact before filing: tokens, URLs, IP addresses, email addresses, names,
   and anything from the user's setup the public need not see — replace each
   with [REDACTED] and keep the wording otherwise. Show the user the finished
@@ -61,6 +78,8 @@ Write "N/A" for any section that is irrelevant.
 List each action you took. For each, record what you did, what resulted, and its status (e.g., Success, Failure).
 
 Mark the first failing step with **[GAP]** in the `Status` column.
+
+One change per row. If one step changed several things, keep them in one row and write "not attributed" in Result; do not split them and assign results you did not observe separately.
 
 | Step | Action | Result | Status |
 |------|--------|--------|-----|
@@ -92,8 +111,14 @@ and tie it to the skill content you quoted in 3a.
 ### 3c. What should the skill have told you instead?
 
 <!--
-Describe the guidance the skill should have included
-to prevent this failure.
+State the HA behaviour the skill should carry, not the fix that worked for
+your setup. Each claim must cite the core file or docs page that shows the
+behaviour; a claim you cannot cite is a hypothesis, so label it as one.
+Hardware models, threshold values, and layout preferences do not go in the
+skill unless the HA behaviour is specific to that integration
+(CONTRIBUTING.md, Guiding Principles: skills apply to any HA installation).
+If you cannot phrase it without them, it is not a skill gap: write
+"No skill gap: instance-specific" here and tell the user before filing.
 -->
 
 ## 4. Impact

--- a/.github/ISSUE_TEMPLATE/skill-rca.md
+++ b/.github/ISSUE_TEMPLATE/skill-rca.md
@@ -31,13 +31,11 @@ A skill in this repository misled you, and your user saw the result.
 BEFORE FILING:
 - Do not re-run any step that changed the user's config. Decide from
   evidence you already have whether the failure is HA's or your tool's:
-  compare the bytes your tool sent with what HA stored, read HA's own log
-  line, check the state the entity actually holds. Corrupted text is
-  usually the tool. A stale cache or an unapplied write can be either; the
-  core file or docs page that produces the behaviour decides. If the
-  evidence points at the tool, there is no skill gap: do not file. If you
-  cannot tell, say so in 3b and file only if the skill's guidance would
-  still have changed what you did.
+  what your tool sent against what HA stored, HA's own log line, the state
+  the entity actually holds, and the core file or docs page that would
+  produce the behaviour. If the evidence points at the tool, there is no
+  skill gap: do not file. If you cannot tell, say so in 3b and file only
+  if the skill's guidance would still have changed what you did.
 - Did the skill actually load? If it never triggered, this is a triggering
   failure, not a content failure: write "Skill did not trigger" in 3a, keep
   the user's request verbatim apart from redactions (it is the prompt that
@@ -45,12 +43,11 @@ BEFORE FILING:
 - Did you follow the skill's guidance? If you skipped guidance that would
   have prevented the failure, that is not a skill bug. Report only what the
   skill got wrong or left out.
-- Did your fix break a rule? A step you marked Success that does something
-  the Critical Anti-Patterns table in the skill's SKILL.md forbids is a
-  second failure, not a fix. The test is the path, not the tool: anything
-  you wrote under .storage/, or any configuration.yaml edit for a
-  UI-configured integration, counts. Mark that row Failure, and in 3c give
-  the supported path or say you did not find one.
+- Did your fix break a rule? A step you marked Success that does what the
+  Critical Anti-Patterns table in the skill's SKILL.md forbids is not a
+  fix. The test is what was written where, not which tool wrote it. Mark
+  that row Failure, keep it in this report, and in 3c give the supported
+  path or say you did not find one.
 - One failure per report. If your timeline has two unrelated [GAP] rows,
   file two reports.
 - Search existing issues for the same skill and failure. If a matching
@@ -79,7 +76,7 @@ List each action you took. For each, record what you did, what resulted, and its
 
 Mark the first failing step with **[GAP]** in the `Status` column.
 
-One change per row. If one step changed several things, keep them in one row and write "not attributed" in Result; do not split them and assign results you did not observe separately.
+One change per row. If one step changed several things, keep them in one row and write "not attributed" in Result.
 
 | Step | Action | Result | Status |
 |------|--------|--------|-----|
@@ -112,13 +109,12 @@ and tie it to the skill content you quoted in 3a.
 
 <!--
 State the HA behaviour the skill should carry, not the fix that worked for
-your setup. Each claim must cite the core file or docs page that shows the
-behaviour; a claim you cannot cite is a hypothesis, so label it as one.
-Hardware models, threshold values, and layout preferences do not go in the
-skill unless the HA behaviour is specific to that integration
+your setup. Cite the core file or docs page for each claim; an uncited
+claim is a hypothesis, so label it as one. Details of your installation
+stay out unless the behaviour is specific to that integration
 (CONTRIBUTING.md, Guiding Principles: skills apply to any HA installation).
-If you cannot phrase it without them, it is not a skill gap: write
-"No skill gap: instance-specific" here and tell the user before filing.
+If you cannot phrase it without them, write "No skill gap:
+instance-specific" here and tell the user before filing.
 -->
 
 ## 4. Impact


### PR DESCRIPTION
## What does this PR do?

Adds guards to the RCA issue template for four failure modes seen in #88 to #92, five reports filed from one agent session. Two attributed tool-side problems to HA (#90, #91). One bundled unrelated changes into a single "success" row, so the fix could not be attributed (#88). All five proposed installation-specific remedies in 3c, and one rested on a false premise (#89) that nothing in the template asked the agent to check.

BEFORE FILING, in the order an agent needs them:

- **Attribution.** Opens with "Do not re-run any step that changed the user's config", then names the evidence to decide from: what the tool sent against what HA stored, HA's own log line, the entity's actual state, and the core file or docs page that would produce the behaviour. If the evidence points at the tool, do not file.
- **Fix check.** A Success row that does what the Critical Anti-Patterns table in SKILL.md forbids is marked Failure and stays in the report, and 3c must give the supported path. The test is what was written where, not which tool wrote it.
- **One failure per report.** Unrelated [GAP] rows go in separate reports.
- **Search existing issues** comes after these, since an agent cannot search for a failure it has not yet characterised.

Timeline: one change per row. A step that changed several things stays in one row marked "not attributed".

3c: each claim cites the core file or docs page that shows the behaviour, or is labelled a hypothesis. Installation details stay out unless the behaviour is integration-specific, with a pointer to CONTRIBUTING's "skills apply to any HA installation". If the gap cannot be stated without them, the agent writes "No skill gap: instance-specific" and tells the user before filing.

Verified by walking the five reports through the revised wording: #90 is not filed, #91's fix and #88's tag rename are demoted, #92's three-change row is marked not attributed so its valid core stands alone, and #89's premise needs a citation. #92, the one accurate report, is unchanged in substance.

## Checklist

- [ ] Tested with real scenarios (if changing skill content). Not skill content. Tested by walking the five filed reports through the revised wording.
- [ ] `README.md` Skill Contents table updated (if reference files were added or removed). Not applicable.
- [ ] Row descriptions and the **Included Skill** summary still match what the files cover (if a reference file's scope changed). Not applicable.
